### PR TITLE
infra: alias and pass in Terraform providers to modules

### DIFF
--- a/deploy/terraform/api-gateway/provider.tf
+++ b/deploy/terraform/api-gateway/provider.tf
@@ -2,13 +2,9 @@ terraform {
   required_version = ">= 0.14.0"
   required_providers {
     aws = {
+      configuration_aliases = [aws.us_east_1]
       source                = "hashicorp/aws"
       version               = "5.15.0"
     }
   }
-}
-
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
 }

--- a/deploy/terraform/compute/provider.tf
+++ b/deploy/terraform/compute/provider.tf
@@ -2,16 +2,11 @@ terraform {
   required_version = ">= 0.14.0"
   required_providers {
     aws = {
-      configuration_aliases = [aws.compute_region]
+      configuration_aliases = [aws.compute_region, aws.us_east_1]
       source                = "hashicorp/aws"
       version               = "5.15.0"
     }
   }
-}
-
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
 }
 
 data "aws_region" "compute_region" {

--- a/deploy/terraform/modules.tf
+++ b/deploy/terraform/modules.tf
@@ -9,6 +9,10 @@ module "api_gateway" {
   db_database = var.db_database
 
   corecheck_data_bucket_url = "https://${aws_s3_bucket.bitcoin-coverage-data.id}.s3.${aws_s3_bucket.bitcoin-coverage-data.region}.amazonaws.com"
+
+  providers = {
+    aws.us_east_1 = aws.us_east_1
+  }
 }
 
 module "compute" {
@@ -33,6 +37,7 @@ module "compute" {
 
   lambda_bucket = aws_s3_bucket.corecheck-lambdas.id
   providers = {
+    aws.us_east_1 = aws.us_east_1
     aws.compute_region = aws.compute_region
   }
 }


### PR DESCRIPTION
While experimenting with LocalStack, it appears the direct declaration of Terraform providers within the modules causes problems because they expect AWS credentials to be available. This PR migrates the modules to accept their providers as parameters, in line with the Terraform documentation [here](https://developer.hashicorp.com/terraform/language/modules/develop/providers#passing-providers-explicitly). This hasn't been an issue so far as all deployments are on AWS, but LocalStack (using [terraform-local](https://github.com/localstack/terraform-local) doesn't appear to register as an AWS provider.

This still needs to be tested with a deployment to AWS to make sure the changes don't break the existing deployment process, and there are still a few blockers to getting LocalStack running, too.