### PR TITLE
infra: ssh_key Terraform variable

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -68,7 +68,7 @@ jobs:
       TF_VAR_datadog_api_key: ${{ secrets.DATADOG_API_KEY }}
       TF_VAR_db_user: ${{ secrets.DB_USER }}
       TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
-      TF_VAR_ssh_pubkey: ${{{ secrets.SSH_PUBKEY }}
+      TF_VAR_ssh_pubkey: ${{{ secrets.SSH_KEY }}
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -68,6 +68,7 @@ jobs:
       TF_VAR_datadog_api_key: ${{ secrets.DATADOG_API_KEY }}
       TF_VAR_db_user: ${{ secrets.DB_USER }}
       TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
+      TF_VAR_ssh_pubkey: ${{{ secrets.SSH_PUBKEY }}
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/deploy/terraform/instances.tf
+++ b/deploy/terraform/instances.tf
@@ -22,8 +22,8 @@ data "aws_ami" "ubuntu_22_04" {
 }
 
 resource "aws_key_pair" "ssh_key" {
-  key_name   = "max-${terraform.workspace}"
-  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILTurm2ONYlzVmFhscmeSHPI4o4JZWM2yL+mYA87uotY max@corecheck"
+  key_name   = "terraform-${terraform.workspace}"
+  public_key = var.ssh_pubkey
 }
 
 resource "aws_eip" "lb" {

--- a/deploy/terraform/variable.tf
+++ b/deploy/terraform/variable.tf
@@ -7,6 +7,7 @@ variable "db_password" {}
 variable "db_database" {
   default = "corecheck"
 }
+variable "ssh_pubkey" {}
 
 variable "github_token" {}
 variable "datadog_api_key" {}


### PR DESCRIPTION
Defines a `ssh_pubkey` Terraform variable so that the SSH key used to configure the DB EC2 instance can be dynamic for other developers. Integrated with the GitHub Action pipeline with the assumption that a `SSH_PUBKEY` secret is defined, so one will need to be set to make sure CI works as expected.

Closes #52 