### PR TITLE
build: Infra lambda build artifacts fixes

### DIFF
--- a/deploy/terraform/api-gateway/lambdas.tf
+++ b/deploy/terraform/api-gateway/lambdas.tf
@@ -9,7 +9,8 @@ locals {
 }
 
 resource "terraform_data" "build_api_lambdas" {
-  triggers_replace = local.function_file_hashes
+  # Remove temporarily because Lambda build is not triggered in CI environment.
+  # triggers_replace = local.function_file_hashes
 
   provisioner "local-exec" {
     command     = "make build-api-lambdas"

--- a/deploy/terraform/compute/statemachine.tf
+++ b/deploy/terraform/compute/statemachine.tf
@@ -127,7 +127,8 @@ locals {
 }
 
 resource "terraform_data" "build_compute_lambdas" {
-  triggers_replace = local.function_file_hashes
+  # Remove temporarily because Lambda build is not triggered in CI environment.
+  # triggers_replace = local.function_file_hashes
 
   provisioner "local-exec" {
     command     = "make build-compute-lambdas && make build-compute-stats-lambda"

--- a/deploy/terraform/instances.tf
+++ b/deploy/terraform/instances.tf
@@ -117,4 +117,7 @@ resource "aws_volume_attachment" "db" {
     command = "docker compose run --remove-orphans --rm -e DB_USER=${var.db_user} -e DB_PASSWORD=${var.db_password} -v ${var.ssh_private_key_file}:/ssh-key -w /app/deploy/ansible util bash -c \"ansible-playbook playbooks/*.yml --private-key /ssh-key --ssh-common-args '-o IdentitiesOnly=yes'\""
     working_dir = local.project_root_path
   }
+
+  # Try to avoid error when instance needs to get replaced on dev.
+  stop_instance_before_detaching = true
 }


### PR DESCRIPTION
Try to resolve the errors from [this build](https://github.com/corecheck/corecheck/actions/runs/14860300913/job/42971116771) on `dev`.
- Stops the `db` instance prior to detaching the EBS volume.
- Removes replacement triggers from the Lambda function build processes (temporarily?) because they weren't getting built under CI.