### PR TITLE
frontend: Add missing check for base_report benchmarks

### DIFF
--- a/frontend/src/routes/[owner]/[repo]/pulls/[number]/Benchmarks.svelte
+++ b/frontend/src/routes/[owner]/[repo]/pulls/[number]/Benchmarks.svelte
@@ -503,12 +503,14 @@
                     <td class="col-type-number col-field-pr">
                         <p
                             use:tooltip={{
-                                text: `master: ${report.base_report.benchmarks_grouped[
+                                text: report.base_report.benchmarks_grouped[benchmark]
+                                    ? `master: ${report.base_report.benchmarks_grouped[
                                     benchmark
                                 ]["totalTime"].toLocaleString("en-US", {
                                     minimumFractionDigits: 2,
                                     maximumFractionDigits: 2,
-                                })}`,
+                                })}`
+                                : "",
                                 position: "left",
                             }}
                         >


### PR DESCRIPTION
the base_report (master) may be missing newly added benchmarks, so when iterating over the report benchmarks from the pull, check for the existence of the base_report benchmark.

Otherwise, this could lead to truncation of the table.