### PR TITLE
docker: remove depends build

### DIFF
--- a/workers/coverage-worker/Dockerfile
+++ b/workers/coverage-worker/Dockerfile
@@ -51,8 +51,6 @@ RUN apt update && apt install -y datadog-agent datadog-signing-keys
 RUN git clone https://github.com/bitcoin/bitcoin.git /tmp/bitcoin
 WORKDIR /tmp/bitcoin
 
-RUN make -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_ZMQ=1 NO_USDT=1 -j$(nproc)
-
 RUN mkdir -p /tmp/bitcoin/releases && ./test/get_previous_releases.py
 
 RUN git config --global user.email "ci@corecheck.dev"

--- a/workers/mutation-worker/Dockerfile
+++ b/workers/mutation-worker/Dockerfile
@@ -43,8 +43,6 @@ RUN git clone https://github.com/bitcoin/bitcoin.git /tmp/bitcoin
 RUN git clone --depth=1 https://github.com/bitcoin-core/qa-assets.git /tmp/bitcoin/qa-assets
 WORKDIR /tmp/bitcoin
 
-RUN make -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_ZMQ=1 NO_USDT=1 -j$(nproc)
-
 RUN mkdir -p /tmp/bitcoin/releases && ./test/get_previous_releases.py
 
 RUN git config --global user.email "ci@corecheck.dev"

--- a/workers/sonar-worker/Dockerfile
+++ b/workers/sonar-worker/Dockerfile
@@ -24,8 +24,6 @@ RUN wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-s
 RUN git clone https://github.com/bitcoin/bitcoin.git /tmp/bitcoin
 WORKDIR /tmp/bitcoin
 
-RUN make -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_ZMQ=1 NO_USDT=1 -j$(nproc)
-
 RUN mkdir -p /tmp/bitcoin/releases && ./test/get_previous_releases.py
 
 RUN git config --global user.email "ci@corecheck.dev"


### PR DESCRIPTION
I'm fairly sure this was previously used to get BDB, however that's no-longer used. This invocation will actually end up building sqlite, as NO_SQLITE became NO_WALLET. Given a depends toolchain file isn't used anywhere in any case, remove this invocation.