### PR TITLE
frontend: highlight selected line on mutation testing screen

### DIFF
--- a/frontend/src/routes/mutation/[...path]/+page.svelte
+++ b/frontend/src/routes/mutation/[...path]/+page.svelte
@@ -1,496 +1,599 @@
 <script>
-  import { onMount } from "svelte";
-  import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
-  import { env } from '$env/dynamic/public'
-  let selectedFile = '';
-  let fileContent = '';
-  let mutationData = {};
-  let expandedLines = new Set();
-  let expanded = new Set(['src', 'src/script', 'src/wallet']);
+    import { onMount, tick } from "svelte";
+    import { page } from "$app/stores";
+    import { get as getStore } from "svelte/store";
+    import { goto } from "$app/navigation";
+    import { env } from "$env/dynamic/public";
 
-  const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/bitcoin/bitcoin/master';
+    let selectedFile = "";
+    let fileContent = "";
+    let mutationData = {};
+    let expandedLines = new Set();
+    let expanded = new Set(["src", "src/script", "src/wallet"]);
+    let highlightedLine = null;
 
-  let mutationsMeta = {};
-  let mutations = [];
-  let countMutations = 0;
+    const GITHUB_RAW_BASE =
+        "https://raw.githubusercontent.com/bitcoin/bitcoin/master";
 
-  onMount(async () => {
-    try {
-      const response = await fetch(env.PUBLIC_ENDPOINT + '/mutations/meta');
-      mutationsMeta = await response.json();
-    } catch (error) {
-        console.error("Failed to fetch mutation metadata:", error);
-    }
+    let mutationsMeta = {};
+    let mutations = [];
+    let countMutations = 0;
 
-    try {
-        const response = await fetch(env.PUBLIC_ENDPOINT + '/mutations');
-        mutations = await response.json();
-    } catch (error) {
-        console.error("Failed to fetch mutations:", error);
-    }
+    // ===== Vertical-only scroll helper =====
+    function scrollLineIntoView(
+        lineNumber,
+        { alignLeft = false, vertical = "center", smooth = false } = {},
+    ) {
+        const el = document.getElementById(`L${lineNumber}`);
+        if (!el) return;
 
-    function countDiffs(jsonData) {
-        return jsonData.reduce((total, file) => {
-            return total + Object.values(file.diffs).reduce((sum, diffArray) => sum + diffArray.length, 0);
-        }, 0);
-    }
+        const container = document.querySelector(".code-container"); // horizontal scroller
 
-    // Subscribe to page store to react to URL changes
-    const unsubscribe = page.subscribe(($page) => {
-        const pathname = $page.url.pathname;
+        const rect = el.getBoundingClientRect();
+        const currentY = window.scrollY;
+        let targetTop;
 
-        if (pathname === '/mutation' || pathname === '/mutation/') {
-            selectedFile = null;
-            return;
+        if (vertical === "start") {
+            const offset = 0; // adjust if you add a fixed header
+            targetTop = currentY + rect.top - offset;
+        } else if (vertical === "end") {
+            targetTop = currentY + rect.bottom - window.innerHeight;
+        } else {
+            targetTop =
+                currentY + rect.top - window.innerHeight / 2 + rect.height / 2;
         }
 
-        // Check if we're on a mutation path
-        if (pathname.startsWith('/mutation/')) {
-            const filePath = pathname.replace('/mutation/', '');
+        window.scrollTo({
+            top: targetTop,
+            left: window.scrollX, // DO NOT change X here
+            behavior: smooth ? "smooth" : "auto",
+        });
 
-            // Verify the file exists in your structure
-            if (fileExists(filePath)) {
-                // Only call handleFileSelect if it's different from current selection
-                if (selectedFile !== filePath) {
-                handleFileSelect(filePath, false); // Don't update URL since we're responding to URL change
+        if (container && alignLeft) {
+            container.scrollLeft = 0; // show start of the line
+        }
+    }
+
+    // Accepts optional lineToFocus
+    async function handleFileSelect(
+        file,
+        updateUrl = true,
+        lineToFocus = null,
+    ) {
+        selectedFile = file;
+
+        if (updateUrl) {
+            const currentHash =
+                typeof window !== "undefined" ? window.location.hash : "";
+            goto(`/mutation/${file}${currentHash}`, { replaceState: false });
+        }
+
+        try {
+            // mutations may still be loading on first paint; this is fine
+            const selected_mutations = mutations.filter((val) =>
+                val.filename.includes(file),
+            );
+            mutationData =
+                selected_mutations[0] && selected_mutations[0].diffs
+                    ? selected_mutations[0].diffs
+                    : {};
+
+            // Fetch file content
+            const githubPath = `${GITHUB_RAW_BASE}/${file}`;
+            const contentResp = await fetch(githubPath);
+            if (!contentResp.ok)
+                throw new Error(`Failed to fetch file: ${contentResp.status}`);
+            fileContent = await contentResp.text();
+
+            await tick(); // ensure lines are in the DOM
+
+            // Prefer explicit param; otherwise fall back to URL hash (handles first-load race)
+            let focus = lineToFocus;
+            if (focus == null && typeof window !== "undefined") {
+                const m = window.location.hash.match(/^#?L(\d+)$/);
+                focus = m ? Number(m[1]) : null;
+            }
+
+            if (focus != null) {
+                highlightedLine = focus;
+                scrollLineIntoView(focus, {
+                    alignLeft: true,
+                    vertical: "center",
+                });
+                if (mutationData[focus]) {
+                    expandedLines = new Set(expandedLines).add(focus);
                 }
             } else {
-                // Handle invalid file path - redirect to main mutation page or show error
-                console.warn(`File not found: ${filePath}`);
-                goto('/mutation', { replaceState: true });
+                highlightedLine = null;
+            }
+        } catch (error) {
+            console.error("Error:", error);
+            fileContent = `Error loading content: ${error.message}`;
+            mutationData = {};
+        }
+    }
+
+    function toggleLine(lineNumber) {
+        expandedLines = new Set(expandedLines);
+        if (expandedLines.has(lineNumber)) expandedLines.delete(lineNumber);
+        else expandedLines.add(lineNumber);
+    }
+
+    function onFileClick(file) {
+        handleFileSelect(file, true);
+    }
+
+    const files = {
+        src: {
+            wallet: { "coinselection.cpp": "content" },
+            script: { "interpreter.cpp": "content" },
+            consensus: {
+                "tx_verify.cpp": "content",
+                "tx_check.cpp": "content",
+                "merkle.cpp": "content",
+            },
+            util: { "asmap.cpp": "content" },
+            "pow.cpp": "content",
+            "addrman.cpp": "content",
+            "txgraph.cpp": "content",
+        },
+    };
+
+    function fileExists(filePath) {
+        const parts = filePath.split("/");
+        let current = files;
+        for (const part of parts) {
+            if (current && typeof current === "object" && part in current)
+                current = current[part];
+            else return false;
+        }
+        return true;
+    }
+
+    function renderTree(tree, path = "") {
+        return Object.entries(tree).map(([name, value]) => {
+            const currentPath = path ? `${path}/${name}` : name;
+            if (typeof value === "string") {
+                return { type: "file", name, path: currentPath };
+            } else {
+                return {
+                    type: "directory",
+                    name,
+                    path: currentPath,
+                    children: renderTree(value, currentPath),
+                };
+            }
+        });
+    }
+    $: treeData = renderTree(files);
+
+    onMount(async () => {
+        // --- 1) Handle the current URL IMMEDIATELY (before any fetch) ---
+        {
+            const { pathname } = getStore(page).url;
+            if (pathname.startsWith("/mutation/")) {
+                const filePath = pathname.replace("/mutation/", "");
+                const m = (
+                    typeof window !== "undefined" ? window.location.hash : ""
+                ).match(/^#?L(\d+)$/);
+                const targetLine = m ? Number(m[1]) : null;
+
+                if (fileExists(filePath)) {
+                    // Don't update URL here; we're responding to current URL
+                    await handleFileSelect(filePath, false, targetLine);
+                }
             }
         }
-    });
 
-    countMutations = countDiffs(mutations);
-    return unsubscribe;
-  });
+        // --- 2) Set up reactive navigation (and handle hash changes later on) ---
+        const unsubscribe = page.subscribe(async ($page) => {
+            const { pathname } = $page.url;
+            // If user navigates to a different file after mount
+            if (pathname.startsWith("/mutation/")) {
+                const filePath = pathname.replace("/mutation/", "");
+                if (fileExists(filePath) && selectedFile !== filePath) {
+                    const m = (
+                        typeof window !== "undefined"
+                            ? window.location.hash
+                            : ""
+                    ).match(/^#?L(\d+)$/);
+                    const targetLine = m ? Number(m[1]) : null;
+                    await handleFileSelect(filePath, false, targetLine);
+                }
+            }
+        });
 
-  const files = {
-    'src': {
-      'wallet': {
-        'coinselection.cpp': 'content',
-      },
-      'script': {
-        'interpreter.cpp': 'content'
-      },
-      'consensus': {
-        'tx_verify.cpp': 'content',
-        'tx_check.cpp': 'content',
-        'merkle.cpp': 'content'
-      },
-      'util': {
-        'asmap.cpp': 'content'
-      },
-      'pow.cpp': 'content',
-      'addrman.cpp': 'content',
-      'txgraph.cpp': 'content'
-    },
-  };
+        // --- 3) Kick off data fetches in parallel (don’t block initial URL handling) ---
+        try {
+            const [metaResp, mutsResp] = await Promise.allSettled([
+                fetch(env.PUBLIC_ENDPOINT + "/mutations/meta"),
+                fetch(env.PUBLIC_ENDPOINT + "/mutations"),
+            ]);
 
-function toggleLine(lineNumber) {
-  expandedLines = new Set(expandedLines);
-  if (expandedLines.has(lineNumber)) {
-    expandedLines.delete(lineNumber);
-  } else {
-    expandedLines.add(lineNumber);
-  }
-}
+            if (metaResp.status === "fulfilled") {
+                mutationsMeta = await metaResp.value.json();
+            } else {
+                console.error(
+                    "Failed to fetch mutation metadata:",
+                    metaResp.reason,
+                );
+            }
 
-function onFileClick(file) {
-  handleFileSelect(file, true); // This will update the URL
-}
+            if (mutsResp.status === "fulfilled") {
+                mutations = await mutsResp.value.json();
+            } else {
+                console.error("Failed to fetch mutations:", mutsResp.reason);
+            }
 
-function fileExists(filePath) {
-  const parts = filePath.split('/');
-  let current = files;
-
-  for (const part of parts) {
-    if (current && typeof current === 'object' && part in current) {
-      current = current[part];
-    } else {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Helper function to get all valid file paths from your structure
-function getAllFilePaths(obj = files, currentPath = '') {
-  let paths = [];
-
-  for (const [key, value] of Object.entries(obj)) {
-    const newPath = currentPath ? `${currentPath}/${key}` : key;
-
-    if (typeof value === 'object' && value !== null) {
-      paths = paths.concat(getAllFilePaths(value, newPath));
-    } else {
-      paths.push(newPath);
-    }
-  }
-
-  return paths;
-}
-
-async function handleFileSelect(file, updateUrl = true) {
-    selectedFile = file;
-
-    // Update URL if requested (default true)
-    if (updateUrl) {
-        goto(`/mutation/${file}`, { replaceState: false });
-    }
-
-    try {
-        const selected_mutations = mutations.filter(val => val.filename.includes(file));
-        if(selected_mutations.length > 0 && 'diffs' in selected_mutations[0]) {
-        mutationData = selected_mutations[0].diffs || {};
-        } else {
-        mutationData = {};
+            // compute count safely
+            if (Array.isArray(mutations)) {
+                countMutations = mutations.reduce((total, file) => {
+                    if (!file?.diffs) return total;
+                    return (
+                        total +
+                        Object.values(file.diffs).reduce(
+                            (sum, diffArray) => sum + diffArray.length,
+                            0,
+                        )
+                    );
+                }, 0);
+            }
+        } catch (e) {
+            console.error("Initial data fetch failed:", e);
         }
 
-        // Fetch file content from GitHub raw URL
-        const githubPath = `${GITHUB_RAW_BASE}/${file}`;
-        const contentResp = await fetch(githubPath);
-        if (!contentResp.ok) {
-        throw new Error(`Failed to fetch file: ${contentResp.status}`);
-        }
-        fileContent = await contentResp.text();
-    } catch (error) {
-        console.error('Error:', error);
-        fileContent = `Error loading content: ${error.message}`;
-        mutationData = {};
-    }
-    }
-
-
-  function toggleDir(path) {
-    expanded = new Set(expanded);
-    if (expanded.has(path)) {
-      expanded.delete(path);
-    } else {
-      expanded.add(path);
-    }
-  }
-
-
-  function renderTree(tree, path = '') {
-    return Object.entries(tree).map(([name, value]) => {
-      const currentPath = path ? `${path}/${name}` : name;
-      if (typeof value === 'string') {
-        return {
-          type: 'file',
-          name,
-          path: currentPath
-        };
-      } else {
-        return {
-          type: 'directory',
-          name,
-          path: currentPath,
-          children: renderTree(value, currentPath)
-        };
-      }
+        return unsubscribe;
     });
-  }
-
-  $: treeData = renderTree(files);
 </script>
 
 <div class="page-wrapper">
-  <!-- File Tree -->
-  <div class="file-tree">
-    <h2 class="text-xl font-bold mb-4">Files</h2>
-    {#each treeData as item}
-      {#if item.type === 'file'}
-        <div
-          class="pl-6 py-1 cursor-pointer hover:bg-gray-200 {selectedFile === item.path ? 'bg-blue-100' : ''}"
-          on:click={() => handleFileSelect(item.path)}
-        >
-          📄 {item.name}
-        </div>
-      {:else}
-        <div>
-          <div
-            class="py-1 cursor-pointer hover:bg-gray-200 flex items-center"
-            on:click={() => toggleDir(item.path)}
-          >
-            <span class="mr-2">{expanded.has(item.path) ? '📂' : '📁'}</span>
-            {item.name}
-          </div>
-          {#if expanded.has(item.path)}
-            <div class="directory">
-              {#each item.children as child}
-                {#if child.type === 'file'}
-                  <div
-                    class="pl-6 py-1 cursor-pointer hover:bg-gray-200 {selectedFile === child.path ? 'bg-blue-100' : ''}"
-                    on:click={() => handleFileSelect(child.path)}
-                  >
-                    📄 {child.name}
-                  </div>
-                {:else}
-                  <div>
-                    <div
-                      class="py-1 cursor-pointer hover:bg-gray-200 flex items-center"
-                      on:click={() => toggleDir(child.path)}
-                    >
-                      <span class="mr-2">{expanded.has(child.path) ? '📂' : '📁'}</span>
-                      {child.name}
-                    </div>
-                    {#if expanded.has(child.path)}
-                      <div class="directory">
-                        {#each child.children as grandChild}
-                          <div
-                            class="pl-6 py-1 cursor-pointer hover:bg-gray-200 {selectedFile === grandChild.path ? 'bg-blue-100' : ''}"
-                            on:click={() => handleFileSelect(grandChild.path)}
-                          >
-                            📄 {grandChild.name}
-                          </div>
-                        {/each}
-                      </div>
-                    {/if}
-                  </div>
-                {/if}
-              {/each}
-            </div>
-          {/if}
-        </div>
-      {/if}
-    {/each}
-  </div>
-
-  {#if !selectedFile}
-    <div class="content">
-      <div class="">
-        <div class="shadow document" style="">
-          <div class="heading" style="">
-            <h2 class="">Mutation Testing</h2>
-          </div>
-
-          <div class="main-content">
-            <div>
-              <span>Last Ran: {new Date(mutationsMeta.created_at)}</span>
-            </div>
-            <div>
-              <span>For Commit: {mutationsMeta.commit}</span>
-            </div>
-            <div>
-              Total unkilled mutants: {countMutations}
-            </div>
-            <div>
-              <a href="{env.PUBLIC_ENDPOINT}/mutations">Raw mutation-core output</a>
-            </div>
-            <div>
-              <br><br>
-              To view the mutants, select a file from the left.
-            </div>
-            <div>
-              <br><br>
-              To see the exact mutation-core commands that corecheck.dev ran, checkout the <a href="https://raw.githubusercontent.com/corecheck/corecheck/refs/heads/master/workers/mutation-worker/entrypoint.sh">entrypoint.sh</a> file for the mutation worker.
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-
-  {/if}
-  <!-- Content View -->
-  {#if selectedFile}
-    <div class="content">
-      <div class="">
-        <div class="shadow document" style="">
-          <div class="heading" style="">
-            <h2 class=""><a on:click={() => goto('/mutation', { replaceState: true })} style="text-decoration: underline;">Mutations</a> -> {selectedFile}</h2>
-          </div>
-
-          <div class="main-content code-container">
-            <div class="code-scroll-wrapper">
-              {#each fileContent.split('\n') as line, index}
-                {@const lineNumber = index + 1}
-                {@const hasMutants = mutationData[lineNumber]}
-                {@const lineColor = hasMutants ? 'text-red-600' : 'text-green-600'}
-
-                <div class="">
-                  <div
-                    style=""
-                    class="line-wrapper {hasMutants ? 'red' : ''}"
-                    on:click={() => hasMutants && toggleLine(lineNumber)}
-                  >
-                    <div class="lineno" style="">
-                      {lineNumber}
-                    </div>
-                    <div class="line">
-                      {#if hasMutants}
-                        <span class="chevron">
-                          {expandedLines.has(lineNumber) ? '▼' : '▶'}
-                        </span>
-                      {/if}
-                      <span><pre>{line}</pre></span>
-                    </div>
-                  </div>
-
-                  {#if expandedLines.has(lineNumber) && hasMutants}
-                    <div class="mutant-container">
-                      {#each hasMutants as mutant}
-                        <div class="" style="margin-bottom: 1rem;">
-                          <div class="mutant-title">
-                            Mutant #{mutant.id} - {mutant.status}
-                          </div>
-                          <div class="mutant-content">
-                            <pre>{mutant.diff}</pre>
-                          </div>
-                        </div>
-                      {/each}
-                    </div>
-                  {/if}
+    <!-- Sidebar -->
+    <aside class="file-tree">
+        <h2 class="text-xl font-bold mb-4">Files</h2>
+        {#each treeData as item}
+            {#if item.type === "file"}
+                <div
+                    class="pl-6 py-1 cursor-pointer hover:bg-gray-200 {selectedFile ===
+                    item.path
+                        ? 'bg-blue-100'
+                        : ''}"
+                    on:click={() => handleFileSelect(item.path)}
+                >
+                    📄 {item.name}
                 </div>
-              {/each}
+            {:else}
+                <div>
+                    <div
+                        class="py-1 cursor-pointer hover:bg-gray-200 flex items-center"
+                        on:click={() => {
+                            expanded = new Set(expanded);
+                            if (expanded.has(item.path))
+                                expanded.delete(item.path);
+                            else expanded.add(item.path);
+                        }}
+                    >
+                        <span class="mr-2"
+                            >{expanded.has(item.path) ? "📂" : "📁"}</span
+                        >
+                        {item.name}
+                    </div>
+                    {#if expanded.has(item.path)}
+                        <div class="directory">
+                            {#each item.children as child}
+                                {#if child.type === "file"}
+                                    <div
+                                        class="pl-6 py-1 cursor-pointer hover:bg-gray-200 {selectedFile ===
+                                        child.path
+                                            ? 'bg-blue-100'
+                                            : ''}"
+                                        on:click={() =>
+                                            handleFileSelect(child.path)}
+                                    >
+                                        📄 {child.name}
+                                    </div>
+                                {:else}
+                                    <div>
+                                        <div
+                                            class="py-1 cursor-pointer hover:bg-gray-200 flex items-center"
+                                            on:click={() => {
+                                                expanded = new Set(expanded);
+                                                if (expanded.has(child.path))
+                                                    expanded.delete(child.path);
+                                                else expanded.add(child.path);
+                                            }}
+                                        >
+                                            <span class="mr-2"
+                                                >{expanded.has(child.path)
+                                                    ? "📂"
+                                                    : "📁"}</span
+                                            >
+                                            {child.name}
+                                        </div>
+                                        {#if expanded.has(child.path)}
+                                            <div class="directory">
+                                                {#each child.children as grandChild}
+                                                    <div
+                                                        class="pl-6 py-1 cursor-pointer hover:bg-gray-200 {selectedFile ===
+                                                        grandChild.path
+                                                            ? 'bg-blue-100'
+                                                            : ''}"
+                                                        on:click={() =>
+                                                            handleFileSelect(
+                                                                grandChild.path,
+                                                            )}
+                                                    >
+                                                        📄 {grandChild.name}
+                                                    </div>
+                                                {/each}
+                                            </div>
+                                        {/if}
+                                    </div>
+                                {/if}
+                            {/each}
+                        </div>
+                    {/if}
+                </div>
+            {/if}
+        {/each}
+    </aside>
+
+    <!-- Landing -->
+    {#if !selectedFile}
+        <main class="content">
+            <div class="shadow document">
+                <div class="heading"><h2>Mutation Testing</h2></div>
+                <div class="main-content">
+                    <div>
+                        <span
+                            >Last Ran: {new Date(
+                                mutationsMeta.created_at,
+                            )}</span
+                        >
+                    </div>
+                    <div><span>For Commit: {mutationsMeta.commit}</span></div>
+                    <div>Total unkilled mutants: {countMutations}</div>
+                    <div>
+                        <a href="{env.PUBLIC_ENDPOINT}/mutations"
+                            >Raw mutation-core output</a
+                        >
+                    </div>
+                    <div>
+                        <br /><br />To view the mutants, select a file from the
+                        left.
+                    </div>
+                    <div>
+                        <br /><br />To see the exact mutation-core commands that
+                        corecheck.dev ran, checkout the
+                        <a
+                            href="https://raw.githubusercontent.com/corecheck/corecheck/refs/heads/master/workers/mutation-worker/entrypoint.sh"
+                            >entrypoint.sh</a
+                        > file for the mutation worker.
+                    </div>
+                </div>
             </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  {/if}
+        </main>
+    {/if}
+
+    <!-- File view -->
+    {#if selectedFile}
+        <main class="content">
+            <div class="shadow document">
+                <div class="heading">
+                    <h2>
+                        <a
+                            on:click={() =>
+                                goto("/mutation", { replaceState: true })}
+                            style="text-decoration: underline;">Mutations</a
+                        >
+                        -> {selectedFile}
+                    </h2>
+                </div>
+
+                <div class="main-content code-container">
+                    <div class="code-scroll-wrapper">
+                        {#each fileContent.split("\n") as line, index}
+                            {@const lineNumber = index + 1}
+                            {@const hasMutants = mutationData[lineNumber]}
+
+                            <div>
+                                <div
+                                    id={"L" + lineNumber}
+                                    class="line-wrapper {hasMutants
+                                        ? 'red'
+                                        : ''} {lineNumber === highlightedLine
+                                        ? 'highlight'
+                                        : ''}"
+                                    on:click={() => {
+                                        if (hasMutants) toggleLine(lineNumber);
+                                        goto(
+                                            `/mutation/${selectedFile}#L${lineNumber}`,
+                                            { replaceState: true },
+                                        );
+                                        highlightedLine = lineNumber;
+                                        // Keep current horizontal position on user click
+                                        scrollLineIntoView(lineNumber, {
+                                            alignLeft: false,
+                                            vertical: "center",
+                                        });
+                                    }}
+                                >
+                                    <div class="lineno">{lineNumber}</div>
+                                    <div class="line">
+                                        {#if hasMutants}
+                                            <span class="chevron"
+                                                >{expandedLines.has(lineNumber)
+                                                    ? "▼"
+                                                    : "▶"}</span
+                                            >
+                                        {/if}
+                                        <span><pre>{line}</pre></span>
+                                    </div>
+                                </div>
+
+                                {#if expandedLines.has(lineNumber) && hasMutants}
+                                    <div class="mutant-container">
+                                        {#each hasMutants as mutant}
+                                            <div style="margin-bottom: 1rem;">
+                                                <div class="mutant-title">
+                                                    Mutant #{mutant.id} - {mutant.status}
+                                                </div>
+                                                <div class="mutant-content">
+                                                    <pre>{mutant.diff}</pre>
+                                                </div>
+                                            </div>
+                                        {/each}
+                                    </div>
+                                {/if}
+                            </div>
+                        {/each}
+                    </div>
+                </div>
+            </div>
+        </main>
+    {/if}
 </div>
 
 <style>
-  .file-tree {
-    position: fixed;
-    width: 300px;
-    height: 100vh;
-    overflow-y: auto;
-    background: #f8f9fa;
-    padding: 1rem;
-    border-right: 1px solid #dee2e6;
-    z-index: 10;
-  }
-
-  @media (max-width: 768px) {
+    /* Layout: grid + sticky sidebar */
+    .page-wrapper {
+        display: grid;
+        grid-template-columns: 300px 1fr;
+        min-height: 100vh;
+    }
     .file-tree {
-      width: 100%;
-      height: auto;
-      max-height: 50vh;
-      position: relative;
-      border-right: none;
-      border-bottom: 1px solid #dee2e6;
+        position: sticky;
+        top: 0;
+        align-self: start;
+        height: 100vh;
+        overflow-y: auto;
+        background: #f8f9fa;
+        padding: 1rem;
+        border-right: 1px solid #dee2e6;
+        z-index: 1;
     }
-
     .content {
-      margin-left: 0 !important;
+        padding: 1rem;
+        background-color: white;
     }
-  }
+    @media (max-width: 768px) {
+        .page-wrapper {
+            grid-template-columns: 1fr;
+        }
+        .file-tree {
+            height: auto;
+            max-height: 50vh;
+        }
+    }
 
-  .content {
-    margin-left: 300px;
-    padding: 1rem;
-    background-color: white;
-  }
-  .content a {
-    cursor: pointer;
-  }
+    .directory {
+        padding-left: 1.5rem;
+    }
+    .shadow {
+        --tw-shadow:
+            0 10px 15px -3px rgba(0, 0, 0, 0.1),
+            0 4px 6px -2px rgba(0, 0, 0, 0.05);
+        box-shadow:
+            0 0 #0000,
+            0 0 #0000,
+            0 0 #0000,
+            0 0 #0000,
+            var(--tw-shadow);
+    }
+    .heading {
+        padding: 1rem;
+        border-bottom: 1px solid rgba(229, 231, 235, 1);
+    }
+    .document {
+        max-width: 100%;
+        margin: 0 auto;
+        font-family:
+            ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+            "Liberation Mono", "Courier New", monospace;
+    }
+    .main-content {
+        padding: 1rem;
+        background-color: rgba(249, 250, 251, 1);
+        min-height: 100vh;
+    }
 
-  .directory {
-    padding-left: 1.5rem;
-  }
-  .shadow {
-    --tw-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),0 4px 6px -2px rgba(0, 0, 0, 0.05);
-    box-shadow: 0 0 #0000,0 0 #0000, 0 0 #0000,0 0 #0000,var(--tw-shadow);
-  }
-  .heading {
-    padding: 1rem;
-    border-bottom-width: 1px;
-    border-style: solid;
-    border-color: rgba(229, 231, 235, 1);
-  }
-  .document {
-    max-width: 100%;
-    margin-right: auto;
-    margin-left: auto;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  }
-  .main-content {
-    padding: 1rem;
-    background-color: rgba(249,250,251,1);
-    min-height: 100vh;
-  }
-  .line {
-    color: rgba(5,150,105,1);
-    flex: 1 1 0%;
-    display: flex;
-    white-space: nowrap;
-  }
+    /* Code view */
+    .code-container {
+        overflow-x: auto;
+        max-width: 100%;
+        padding-left: 12px; /* left gutter */
+        scroll-padding-left: 12px; /* if any future scrollIntoView is used */
+    }
+    .code-scroll-wrapper {
+        min-width: min-content;
+        white-space: nowrap;
+    }
+    .code-container::-webkit-scrollbar {
+        height: 8px;
+    }
+    .code-container::-webkit-scrollbar-track {
+        background: #edf2f7;
+    }
+    .code-container::-webkit-scrollbar-thumb {
+        background-color: #cbd5e0;
+        border-radius: 4px;
+    }
 
-  /* Container for the code with horizontal scrollbar */
-  .code-container {
-    overflow-x: auto;
-    max-width: 100%;
-  }
-
-  .code-scroll-wrapper {
-    min-width: min-content;
-    white-space: nowrap;
-  }
-
-  .code-container::-webkit-scrollbar {
-    height: 8px;
-  }
-
-  .code-container::-webkit-scrollbar-track {
-    background: #edf2f7;
-  }
-
-  .code-container::-webkit-scrollbar-thumb {
-    background-color: #cbd5e0;
-    border-radius: 4px;
-  }
-
-  .lineno {
-    color: rgba(107,114,128,1);
-    width: 3rem;
-    flex-shrink: 0;
-  }
-  .line-wrapper {
-    display: flex;
-    align-items: flex-start;
-    width: 100%;
-  }
-  .chevron {
-    margin-right: 0.5rem;
-    flex-shrink: 0;
-  }
-  .red {
-    background-color: rgba(254,226,226,1);
-  }
-  .mutant-container {
-    padding-left: 1rem;
-    border-style: solid;
-    border-left-width: 2px;
-    border-color: rgba(229,231,235,1);
-    margin-left: 3rem;
-    margin-bottom: .5rem;
-    margin-top: .5rem;
-    width: calc(100% - 3rem);
-  }
-  .mutant-title {
-    color: rgba(75,85,99,1);
-  }
-  .mutant-content {
-    font-size: .875rem;
-    line-height: 1.25rem;
-    padding: 0.5rem;
-    background-color: rgba(243,244,246,1);
-    overflow: hidden;
-  }
-
-  @media (max-width: 480px) {
+    .line {
+        color: rgba(5, 150, 105, 1);
+        flex: 1 1 0%;
+        display: flex;
+        white-space: nowrap;
+    }
     .lineno {
-      width: 2rem;
+        color: rgba(107, 114, 128, 1);
+        width: 3rem;
+        flex-shrink: 0;
+    }
+    .line-wrapper {
+        display: flex;
+        align-items: flex-start;
+        width: 100%;
+        scroll-margin-left: 12px;
+    }
+    .chevron {
+        margin-right: 0.5rem;
+        flex-shrink: 0;
+    }
+    .red {
+        background-color: rgba(254, 226, 226, 1);
     }
 
     .mutant-container {
-      margin-left: 2rem;
-      width: calc(100% - 2rem);
+        padding-left: 1rem;
+        border-left: 2px solid rgba(229, 231, 235, 1);
+        margin-left: 3rem;
+        margin-bottom: 0.5rem;
+        margin-top: 0.5rem;
+        width: calc(100% - 3rem);
     }
-  }
+    .mutant-title {
+        color: rgba(75, 85, 99, 1);
+    }
+    .mutant-content {
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+        padding: 0.5rem;
+        background-color: rgba(243, 244, 246, 1);
+        overflow: hidden;
+    }
+
+    .highlight {
+        outline: 2px solid rgba(59, 130, 246, 0.6);
+        background-color: rgba(219, 234, 254, 0.6);
+    }
+
+    @media (max-width: 480px) {
+        .lineno {
+            width: 2rem;
+        }
+        .mutant-container {
+            margin-left: 2rem;
+            width: calc(100% - 2rem);
+        }
+    }
 </style>


### PR DESCRIPTION
This PR changes the mutation testing page on front-end to highlight the line when clicked. Also, we can specify which line it should highlight using the URL (e.g. `mutation/src/script/interpreter.cpp#L101` - it will load the page with the line 101 focused and highlighted) - it's useful when opening a PR on Bitcoin Core adding a test to kill a specific mutant because we can share exactly what it's being addressed. Example:

<img width="1304" height="686" alt="Screenshot 2025-10-02 at 16 09 47" src="https://github.com/user-attachments/assets/fc085c18-1c13-4ea0-b0a7-11adb1d25b84" />
