### PR TITLE
Attempt to run ansible as part of terraform to avoid chicken and egg

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -91,6 +91,19 @@ jobs:
         aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws configure set default.region eu-west-3
 
+    - name: Setup SSH key for Ansible
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+
+    - name: Install Ansible
+      run: |
+        sudo apt update
+        sudo apt install -y software-properties-common
+        sudo apt-add-repository --yes --update ppa:ansible/ansible
+        sudo apt install -y ansible
+
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
       run: terraform init
@@ -100,61 +113,4 @@ jobs:
 
     - name: Terraform Apply
       run: terraform apply -auto-approve -input=false
-    - name: Upload hosts.ini
-      uses: actions/upload-artifact@v4
-      with:
-        name: hosts.ini
-        path: deploy/ansible/hosts.ini
-  ansible:
-    name: 'Ansible'
-    needs: terraform
-    runs-on: ubuntu-latest
-    environment: production
-
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./deploy/ansible
-
-    env:
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-
-      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      PLAUSIBLE_DB_PASSWORD: ${{ secrets.PLAUSIBLE_DB_PASSWORD }}
-      PLAUSIBLE_SECRET_KEY_BASE: ${{ secrets.PLAUSIBLE_SECRET_KEY_BASE }}
-      
-      PYTHONUNBUFFERED: "1"
-
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Setup SSH key
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
-        chmod 600 ~/.ssh/id_ed25519
-
-    - name: Download a single artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: hosts.ini
-        path: deploy/ansible
-
-    - name: Install Ansible
-      run: |
-        sudo apt update
-        sudo apt install software-properties-common
-        sudo apt-add-repository --yes --update ppa:ansible/ansible
-        sudo apt install ansible
-
-    - name: Ansible Playbook
-      run: ansible-playbook playbooks/*.yml
 

--- a/deploy/terraform/compute/provisioners.tf
+++ b/deploy/terraform/compute/provisioners.tf
@@ -1,0 +1,22 @@
+resource "null_resource" "configure_db" {
+  triggers = {
+    instance_id    = var.db_instance_id
+    inventory_path = var.ansible_inventory_path
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      cd "${path.root}/../ansible"
+      ansible-playbook playbooks/00_setup_disk.yml playbooks/01_install_docker.yml playbooks/02_ssh.yml playbooks/03_setup_db.yml
+    EOT
+
+    environment = {
+      DB_USER                   = var.db_user
+      DB_PASSWORD               = var.db_password
+      ANSIBLE_INVENTORY         = var.ansible_inventory_path
+      ANSIBLE_HOST_KEY_CHECKING = "False"
+      ANSIBLE_PRIVATE_KEY_FILE  = pathexpand("~/.ssh/id_ed25519")
+    }
+  }
+}

--- a/deploy/terraform/compute/statemachine.tf
+++ b/deploy/terraform/compute/statemachine.tf
@@ -172,17 +172,17 @@ resource "aws_lambda_function" "function" {
 }
 
 
-# resource "aws_lambda_invocation" "invoke" {
-#   provider = aws.compute_region
-#   function_name = "migrate-${terraform.workspace}"
-#   input         = "{\"action\": \"up\"}"
-#   triggers = {
-#     always_run = timestamp()
-#   }
-#   depends_on = [
-#     aws_lambda_function.function,
-#   ]
-# }
+resource "aws_lambda_invocation" "run_migrations" {
+  provider      = aws.compute_region
+  function_name = aws_lambda_function.function["migrate"].function_name
+  input         = jsonencode({ action = "up" })
+  triggers = {
+    always_run = timestamp()
+  }
+  depends_on = [
+    null_resource.configure_db,
+  ]
+}
 
 resource "aws_cloudwatch_event_rule" "github_sync" {
   provider = aws.compute_region

--- a/deploy/terraform/compute/vars.tf
+++ b/deploy/terraform/compute/vars.tf
@@ -23,6 +23,16 @@ variable "db_database" {
   description = "db database"
 }
 
+variable "db_instance_id" {
+  type        = string
+  description = "db instance id"
+}
+
+variable "ansible_inventory_path" {
+  type        = string
+  description = "absolute path to the generated ansible inventory"
+}
+
 variable "github_token" {
   type        = string
   description = "github token"

--- a/deploy/terraform/modules.tf
+++ b/deploy/terraform/modules.tf
@@ -25,6 +25,8 @@ module "compute" {
   db_user     = var.db_user
   db_password = var.db_password
   db_database = var.db_database
+  db_instance_id = aws_instance.db.id
+  ansible_inventory_path = abspath(local_file.hosts.filename)
 
   github_token          = var.github_token
   corecheck_data_bucket = aws_s3_bucket.bitcoin-coverage-data.id
@@ -42,4 +44,8 @@ module "compute" {
     aws.us_east_1 = aws.us_east_1
     aws.compute_region = aws.compute_region
   }
+
+  depends_on = [
+    aws_volume_attachment.db,
+  ]
 }

--- a/deploy/terraform/providers.tf
+++ b/deploy/terraform/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.15.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.1"
+    }
   }
 
   backend "s3" {


### PR DESCRIPTION
Runs ansible as part of the terraform code which means the database migrations can depend on the db setup from ansible. This should stop the chicken and egg problem of terraform migration needing ansible which in turn needed terraform to have run first.

Fixes: #62

Tested on dev first: https://github.com/corecheck/corecheck/actions/runs/19735994852