### PR TITLE
Adding trace information to reports

### DIFF
--- a/deploy/terraform/compute/statemachine.tf
+++ b/deploy/terraform/compute/statemachine.tf
@@ -341,7 +341,11 @@ resource "aws_sfn_state_machine" "state_machine" {
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "handle-coverage-${terraform.workspace}:$LATEST",
-        "Payload.$": "$"
+        "Payload": {
+          "params.$": "$.params",
+          "coverage_job.$": "$.coverage_job",
+          "step_function_execution_arn.$": "$$.Execution.Id"
+        }
       },
       "Next": "Parallel",
       "ResultPath": "$.coverage_result"

--- a/frontend/src/routes/[owner]/[repo]/pulls/[number]/+page.svelte
+++ b/frontend/src/routes/[owner]/[repo]/pulls/[number]/+page.svelte
@@ -101,6 +101,22 @@
                     </span>
                 </div>
             {/if}
+            {#if report}
+                <div
+                    id="report-debug-trace"
+                    hidden
+                    aria-hidden="true"
+                    data-report-id={report.id}
+                    data-report-commit={report.commit}
+                    data-step-function-execution-arn={report.step_function_execution_arn ||
+                        ""}
+                    data-coverage-batch-job-id={report.coverage_batch_job_id || ""}
+                >
+                    step_function_execution_arn={report.step_function_execution_arn ||
+                        ""}; coverage_batch_job_id={report.coverage_batch_job_id ||
+                        ""}
+                </div>
+            {/if}
         </div>
         <div class="clearfix m-b-base" />
 

--- a/functions/compute/github-sync/main.go
+++ b/functions/compute/github-sync/main.go
@@ -79,10 +79,20 @@ func checkMasterCoverage(c *github.Client) error {
 		log.Error(err)
 		return err
 	}
-	_, err = stateMachine.StartExecution(&sfn.StartExecutionInput{
+	execution, err := stateMachine.StartExecution(&sfn.StartExecutionInput{
 		StateMachineArn: aws.String(cfg.StateMachineARN),
 		Input:           aws.String(string(paramsJson)),
 	})
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	err = db.UpdateCoverageReportTrace(report.ID, aws.StringValue(execution.ExecutionArn), "")
+	if err != nil {
+		log.Errorf("Error updating coverage report trace: %s", err)
+		return err
+	}
 
 	err, runMutations := isTimeToRunMutationsAgain()
 	if err != nil {
@@ -215,13 +225,18 @@ func handlePullRequest(pr *github.PullRequest) error {
 			return err
 		}
 
-		_, err = stateMachine.StartExecution(&sfn.StartExecutionInput{
+		execution, err := stateMachine.StartExecution(&sfn.StartExecutionInput{
 			StateMachineArn: aws.String(cfg.StateMachineARN),
 			Input:           aws.String(string(paramsJson)),
 		})
-
 		if err != nil {
 			log.Error(err)
+			return err
+		}
+
+		err = db.UpdateCoverageReportTrace(report.ID, aws.StringValue(execution.ExecutionArn), "")
+		if err != nil {
+			log.Errorf("Error updating coverage report trace: %s", err)
 			return err
 		}
 	}

--- a/functions/compute/handle-coverage/main.go
+++ b/functions/compute/handle-coverage/main.go
@@ -22,11 +22,19 @@ var (
 
 func handleCodeCoverageSuccess(job *types.JobParams) error {
 	log.Info("Handling code coverage success")
+	stepFunctionExecutionARN := job.GetStepFunctionExecutionARN()
+	coverageBatchJobID := job.GetCoverageBatchJobID()
 
 	if job.GetIsMaster() {
 		report, err := db.GetOrCreateCoverageReportByCommitMaster(job.Commit)
 		if err != nil {
 			log.Error("Error getting coverage report", err)
+			return err
+		}
+
+		err = db.UpdateCoverageReportTrace(report.ID, stepFunctionExecutionARN, coverageBatchJobID)
+		if err != nil {
+			log.Error("Error updating coverage report trace", err)
 			return err
 		}
 
@@ -43,6 +51,12 @@ func handleCodeCoverageSuccess(job *types.JobParams) error {
 	report, err := db.GetOrCreateCoverageReportByCommitPr(job.Commit, job.GetPRNumber(), job.BaseCommit)
 	if err != nil {
 		log.Error("Error getting coverage report", err)
+		return err
+	}
+
+	err = db.UpdateCoverageReportTrace(report.ID, stepFunctionExecutionARN, coverageBatchJobID)
+	if err != nil {
+		log.Error("Error updating coverage report trace", err)
 		return err
 	}
 

--- a/functions/compute/rerun-all/main.go
+++ b/functions/compute/rerun-all/main.go
@@ -89,11 +89,17 @@ func HandleRequest(ctx context.Context, event interface{}) (string, error) {
 			return "", err
 		}
 
-		_, err = stateMachine.StartExecution(&sfn.StartExecutionInput{
+		execution, err := stateMachine.StartExecution(&sfn.StartExecutionInput{
 			StateMachineArn: aws.String(cfg.StateMachineARN),
 			Input:           aws.String(string(paramsJson)),
 		})
 
+		if err != nil {
+			log.Error(err)
+			return "", err
+		}
+
+		err = db.UpdateCoverageReportTrace(report.ID, aws.StringValue(execution.ExecutionArn), "")
 		if err != nil {
 			log.Error(err)
 			return "", err

--- a/internal/db/coverage.go
+++ b/internal/db/coverage.go
@@ -15,19 +15,21 @@ const (
 )
 
 type CoverageReport struct {
-	ID                int                                      `json:"id,omitempty" gorm:"primaryKey"`
-	Status            string                                   `json:"status" gorm:"default:pending"`
-	BenchmarkStatus   string                                   `json:"benchmark_status" gorm:"default:pending"`
-	IsMaster          bool                                     `json:"is_master"`
-	PRNumber          int                                      `json:"pr_number"`
-	Commit            string                                   `json:"commit"`
-	BaseCommit        string                                   `json:"base_commit"`
-	BaseReport        *CoverageReport                          `json:"base_report" gorm:"-"`
-	Benchmarks        []BenchmarkResult                        `json:"-" gorm:"foreignKey:CoverageReportID;constraint:OnDelete:CASCADE"`
-	BenchmarksGrouped map[string]*BenchmarkResult              `json:"benchmarks_grouped" gorm:"-"`
-	Hunks             []CoverageFileHunk                       `json:"-" gorm:"foreignKey:CoverageReportID;constraint:OnDelete:CASCADE"`
-	Coverage          map[string]map[string][]CoverageFileHunk `json:"coverage" gorm:"-"`
-	CreatedAt         time.Time                                `json:"created_at"`
+	ID                       int                                      `json:"id,omitempty" gorm:"primaryKey"`
+	Status                   string                                   `json:"status" gorm:"default:pending"`
+	BenchmarkStatus          string                                   `json:"benchmark_status" gorm:"default:pending"`
+	IsMaster                 bool                                     `json:"is_master"`
+	PRNumber                 int                                      `json:"pr_number"`
+	Commit                   string                                   `json:"commit"`
+	BaseCommit               string                                   `json:"base_commit"`
+	StepFunctionExecutionARN string                                   `json:"step_function_execution_arn"`
+	CoverageBatchJobID       string                                   `json:"coverage_batch_job_id"`
+	BaseReport               *CoverageReport                          `json:"base_report" gorm:"-"`
+	Benchmarks               []BenchmarkResult                        `json:"-" gorm:"foreignKey:CoverageReportID;constraint:OnDelete:CASCADE"`
+	BenchmarksGrouped        map[string]*BenchmarkResult              `json:"benchmarks_grouped" gorm:"-"`
+	Hunks                    []CoverageFileHunk                       `json:"-" gorm:"foreignKey:CoverageReportID;constraint:OnDelete:CASCADE"`
+	Coverage                 map[string]map[string][]CoverageFileHunk `json:"coverage" gorm:"-"`
+	CreatedAt                time.Time                                `json:"created_at"`
 }
 
 type CoverageFileHunkLine struct {
@@ -122,6 +124,13 @@ func UpdateCoverageReport(reportID int, status string, benchStatus string, baseC
 		"status":           status,
 		"benchmark_status": benchStatus,
 		"base_commit":      baseCommit,
+	}).Error
+}
+
+func UpdateCoverageReportTrace(reportID int, stepFunctionExecutionARN string, coverageBatchJobID string) error {
+	return DB.Model(&CoverageReport{}).Where("id = ?", reportID).Updates(map[string]interface{}{
+		"step_function_execution_arn": stepFunctionExecutionARN,
+		"coverage_batch_job_id":       coverageBatchJobID,
 	}).Error
 }
 

--- a/internal/types/job.go
+++ b/internal/types/job.go
@@ -3,10 +3,12 @@ package types
 import "strconv"
 
 type JobParams struct {
-	PRNumber   string `json:"pr_number"`
-	Commit     string `json:"commit"`
-	BaseCommit string `json:"base_commit"`
-	IsMaster   string `json:"is_master"`
+	PRNumber                 string `json:"pr_number"`
+	Commit                   string `json:"commit"`
+	BaseCommit               string `json:"base_commit"`
+	IsMaster                 string `json:"is_master"`
+	StepFunctionExecutionARN string `json:"step_function_execution_arn,omitempty"`
+	CoverageBatchJobID       string `json:"coverage_batch_job_id,omitempty"`
 }
 
 func (j *JobParams) GetPRNumber() int {
@@ -27,6 +29,14 @@ func (j *JobParams) GetBaseCommit() string {
 	return j.BaseCommit
 }
 
+func (j *JobParams) GetStepFunctionExecutionARN() string {
+	return j.StepFunctionExecutionARN
+}
+
+func (j *JobParams) GetCoverageBatchJobID() string {
+	return j.CoverageBatchJobID
+}
+
 func getJobParams(event map[string]interface{}) (*JobParams, error) {
 	params := event["params"].(map[string]interface{})
 	commit := params["commit"].(string)
@@ -35,13 +45,30 @@ func getJobParams(event map[string]interface{}) (*JobParams, error) {
 	baseCommit := params["base_commit"].(string)
 
 	return &JobParams{
-		PRNumber:   prNumber,
-		Commit:     commit,
-		IsMaster:   isMaster,
-		BaseCommit: baseCommit,
+		PRNumber:                 prNumber,
+		Commit:                   commit,
+		IsMaster:                 isMaster,
+		BaseCommit:               baseCommit,
+		StepFunctionExecutionARN: getStepFunctionExecutionARN(event),
+		CoverageBatchJobID:       getCoverageBatchJobID(event),
 	}, nil
 }
 
 func GetJobParams(event map[string]interface{}) (*JobParams, error) {
 	return getJobParams(event)
+}
+
+func getStepFunctionExecutionARN(event map[string]interface{}) string {
+	executionARN, _ := event["step_function_execution_arn"].(string)
+	return executionARN
+}
+
+func getCoverageBatchJobID(event map[string]interface{}) string {
+	coverageJob, ok := event["coverage_job"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	jobID, _ := coverageJob["JobId"].(string)
+	return jobID
 }


### PR DESCRIPTION
Helps in diagnosing which AWS job caused which report (or more likely tracing it backwards from report to AWS job)