### PR TITLE
frontend: tell coverage is for unit and functional tests

### DIFF
--- a/frontend/src/routes/master-coverage/+page.svelte
+++ b/frontend/src/routes/master-coverage/+page.svelte
@@ -28,7 +28,7 @@
                 <div class="eyebrow">Master coverage</div>
                 <h1>LLVM coverage report for bitcoin/bitcoin master</h1>
                 <p class="subtitle">
-                    RAW HTML Coverage report generated with `llvm-cov show --format=html`
+                    RAW HTML Coverage report generated with `llvm-cov show --format=html` for unit and functional tests
                 </p>
             </div>
 


### PR DESCRIPTION
I think it would be useful to tell the coverage report covers unit and functional tests. Perhaps we could have a similar page for fuzzing.