### PR TITLE
Add master fuzz coverage report pipeline

### DIFF
--- a/.github/workflows/fuzz-coverage-worker.yml
+++ b/.github/workflows/fuzz-coverage-worker.yml
@@ -1,0 +1,37 @@
+name: Build Fuzz Coverage Worker
+on:
+  push:
+    branches: [ "master" , "dev" ]
+    paths:
+      - 'workers/fuzz-coverage-worker/**'
+  workflow_dispatch:
+
+jobs:
+  build_fuzz_coverage:
+    name: fuzz-coverage-worker
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Setup env variables
+      run: |
+        if [[ ${{ github.ref }} == 'refs/heads/dev' ]]; then
+          echo "FUZZ_COVERAGE_IMAGE=public.ecr.aws/i3s2n0b6/corecheck-fuzz-coverage-worker-dev:latest" >> $GITHUB_ENV
+        else
+          echo "FUZZ_COVERAGE_IMAGE=public.ecr.aws/i3s2n0b6/corecheck-fuzz-coverage-worker-default:latest" >> $GITHUB_ENV
+        fi
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Configure AWS CLI
+      run: aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} && aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} && aws configure set region us-east-1
+    - name: Login to ECR
+      run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/i3s2n0b6
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v6
+      with:
+        context: workers/fuzz-coverage-worker
+        push: true
+        platforms: linux/arm64
+        tags: ${{ env.FUZZ_COVERAGE_IMAGE }}

--- a/deploy/terraform/api-gateway/api_gateway.tf
+++ b/deploy/terraform/api-gateway/api_gateway.tf
@@ -33,6 +33,12 @@ resource "aws_api_gateway_resource" "master_coverage" {
   path_part   = "master-coverage"
 }
 
+resource "aws_api_gateway_resource" "master_fuzz_coverage" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  parent_id   = aws_api_gateway_rest_api.api.root_resource_id
+  path_part   = "master-fuzz-coverage"
+}
+
 resource "aws_api_gateway_resource" "mutations_meta" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   parent_id   = aws_api_gateway_resource.mutations.id
@@ -71,6 +77,13 @@ resource "aws_api_gateway_method" "get_master_coverage" {
   authorization = "NONE"
   http_method   = "GET"
   resource_id   = aws_api_gateway_resource.master_coverage.id
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+}
+
+resource "aws_api_gateway_method" "get_master_fuzz_coverage" {
+  authorization = "NONE"
+  http_method   = "GET"
+  resource_id   = aws_api_gateway_resource.master_fuzz_coverage.id
   rest_api_id   = aws_api_gateway_rest_api.api.id
 }
 
@@ -140,6 +153,15 @@ resource "aws_api_gateway_integration" "lambda_master_coverage" {
   uri                     = aws_lambda_function.lambda["get-master-coverage"].invoke_arn
 }
 
+resource "aws_api_gateway_integration" "lambda_master_fuzz_coverage" {
+  http_method             = aws_api_gateway_method.get_master_fuzz_coverage.http_method
+  resource_id             = aws_api_gateway_resource.master_fuzz_coverage.id
+  rest_api_id             = aws_api_gateway_rest_api.api.id
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.lambda["get-master-fuzz-coverage"].invoke_arn
+}
+
 resource "aws_api_gateway_integration" "lambda_mutation_meta" {
   http_method             = aws_api_gateway_method.get_mutation_meta.http_method
   resource_id             = aws_api_gateway_resource.mutations_meta.id
@@ -164,9 +186,11 @@ resource "aws_api_gateway_deployment" "api" {
     aws_api_gateway_method.get_report,
     aws_api_gateway_method.get_mutation,
     aws_api_gateway_method.get_master_coverage,
+    aws_api_gateway_method.get_master_fuzz_coverage,
     aws_api_gateway_integration.lambda,
     aws_api_gateway_integration.lambda_mutation,
     aws_api_gateway_integration.lambda_master_coverage,
+    aws_api_gateway_integration.lambda_master_fuzz_coverage,
     aws_api_gateway_integration.lambda_mutation_meta,
   ]
 }

--- a/deploy/terraform/api-gateway/lambdas.tf
+++ b/deploy/terraform/api-gateway/lambdas.tf
@@ -1,6 +1,7 @@
 locals {
   api_lambdas = [
     "get-master-coverage",
+    "get-master-fuzz-coverage",
     "get-pull",
     "list-pulls",
     "get-report",

--- a/deploy/terraform/compute/batch_fuzz_coverage.tf
+++ b/deploy/terraform/compute/batch_fuzz_coverage.tf
@@ -1,0 +1,76 @@
+resource "aws_batch_job_definition" "fuzz_coverage_job" {
+  name     = "fuzz-coverage-job-${terraform.workspace}"
+  type     = "container"
+  provider = aws.compute_region
+
+  retry_strategy {
+    evaluate_on_exit {
+      on_status_reason = "Host EC2*"
+      action           = "RETRY"
+    }
+
+    evaluate_on_exit {
+      on_reason = "*"
+      action    = "EXIT"
+    }
+
+    attempts = 5
+  }
+
+  container_properties = jsonencode({
+    image = aws_ecrpublic_repository.corecheck-fuzz-coverage-worker.repository_uri
+
+    resourceRequirements = [
+      {
+        type  = "VCPU"
+        value = "8",
+      },
+      {
+        type  = "MEMORY"
+        value = "15000",
+      }
+    ]
+
+    environment = [
+      {
+        name  = "SCCACHE_BUCKET",
+        value = aws_s3_bucket.corecheck-ccache.id
+      },
+      {
+        name  = "SCCACHE_REGION",
+        value = data.aws_region.compute_region.name
+      },
+      {
+        name  = "AWS_ACCESS_KEY_ID",
+        value = var.aws_access_key_id
+      },
+      {
+        name  = "AWS_SECRET_ACCESS_KEY",
+        value = var.aws_secret_access_key
+      },
+      {
+        name  = "S3_BUCKET_DATA",
+        value = var.corecheck_data_bucket
+      },
+      {
+        name  = "S3_BUCKET_ARTIFACTS",
+        value = aws_s3_bucket.corecheck-artifacts.id
+      },
+      {
+        name  = "DD_API_KEY",
+        value = var.datadog_api_key
+      }
+    ]
+
+    command = [
+      "/entrypoint.sh",
+      "Ref::commit",
+    ]
+
+    executionRoleArn = aws_iam_role.job_role.arn
+    jobRoleArn       = aws_iam_role.job_role.arn
+  })
+  timeout {
+    attempt_duration_seconds = 14400
+  }
+}

--- a/deploy/terraform/compute/ecr.tf
+++ b/deploy/terraform/compute/ecr.tf
@@ -4,6 +4,12 @@ resource "aws_ecrpublic_repository" "corecheck-coverage-worker" {
   force_destroy   = true
 }
 
+resource "aws_ecrpublic_repository" "corecheck-fuzz-coverage-worker" {
+  provider        = aws.us_east_1
+  repository_name = "corecheck-fuzz-coverage-worker-${terraform.workspace}"
+  force_destroy   = true
+}
+
 resource "aws_ecrpublic_repository" "corecheck-bench-worker" {
   provider        = aws.us_east_1
   repository_name = "corecheck-bench-worker-${terraform.workspace}"

--- a/deploy/terraform/compute/statemachine.tf
+++ b/deploy/terraform/compute/statemachine.tf
@@ -6,6 +6,7 @@ locals {
     "migrate",
     "handle-coverage",
     "handle-coverage-failure",
+    "handle-fuzz-coverage",
     "handle-benchmarks",
     "handle-mutation",
     "rerun-all",
@@ -29,6 +30,7 @@ locals {
           GITHUB_ACCESS_TOKEN        = var.github_token
           STATE_MACHINE_ARN          = aws_sfn_state_machine.state_machine.arn
           MUTATION_STATE_MACHINE_ARN = aws_sfn_state_machine.mutation_state_machine.arn
+          FUZZ_STATE_MACHINE_ARN     = aws_sfn_state_machine.fuzz_state_machine.arn
         }
       }
     },
@@ -68,6 +70,21 @@ locals {
     },
     "handle-coverage-failure" = {
       timeout                = 60
+      memory_size            = 128
+      ephemeral_storage_size = 512
+      environment = {
+        variables = {
+          DATABASE_HOST     = var.db_host
+          DATABASE_PORT     = var.db_port
+          DATABASE_USER     = var.db_user
+          DATABASE_PASSWORD = var.db_password
+          DATABASE_NAME     = var.db_database
+          DATABASE_SSLMODE  = var.db_sslmode
+        }
+      }
+    },
+    "handle-fuzz-coverage" = {
+      timeout                = 900
       memory_size            = 128
       ephemeral_storage_size = 512
       environment = {
@@ -482,6 +499,47 @@ resource "aws_sfn_state_machine" "mutation_state_machine" {
       },
       "End": true,
       "ResultPath": "$.mutation_result"
+    }
+  }
+}
+EOF
+}
+
+resource "aws_sfn_state_machine" "fuzz_state_machine" {
+  name     = "start-fuzz-jobs-${terraform.workspace}"
+  role_arn = aws_iam_role.state_machine_role.arn
+  provider = aws.compute_region
+
+  definition = <<EOF
+{
+  "Comment": "Starts the fuzz coverage batch job (corpus replay) and records the result",
+  "StartAt": "Start fuzz coverage",
+  "States": {
+    "Start fuzz coverage": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::batch:submitJob.sync",
+      "Parameters": {
+        "Parameters.$": "$.params",
+        "JobDefinition": "${aws_batch_job_definition.fuzz_coverage_job.arn}",
+        "JobName": "fuzz-coverage",
+        "JobQueue": "${aws_batch_job_queue.coverage_queue.arn}"
+      },
+      "ResultPath": "$.coverage_job",
+      "Next": "Handle fuzz coverage"
+    },
+    "Handle fuzz coverage": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "handle-fuzz-coverage-${terraform.workspace}:$LATEST",
+        "Payload": {
+          "params.$": "$.params",
+          "coverage_job.$": "$.coverage_job",
+          "step_function_execution_arn.$": "$$.Execution.Id"
+        }
+      },
+      "ResultPath": "$.coverage_result",
+      "End": true
     }
   }
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -61,6 +61,19 @@
             </a>
             <a
                 data-sveltekit-preload-code="eager"
+                href="/master-fuzz-coverage"
+                class="menu-item"
+                aria-label="Fuzz coverage"
+                class:active={$page.url.pathname.includes("/master-fuzz-coverage")}
+                use:tooltip={{ text: "Fuzz coverage", position: "right" }}
+            >
+                <span class="menu-item-icon">
+                    <i class="ri-bug-line" />
+                </span>
+                <span class="menu-item-label">Fuzz coverage</span>
+            </a>
+            <a
+                data-sveltekit-preload-code="eager"
                 href="/tests"
                 class="menu-item"
                 aria-label="Tests"

--- a/frontend/src/routes/master-fuzz-coverage/+page.server.ts
+++ b/frontend/src/routes/master-fuzz-coverage/+page.server.ts
@@ -1,0 +1,61 @@
+import { env } from "$env/dynamic/public";
+
+const COVERAGE_TOTAL_LABELS = [
+    "Function Coverage",
+    "Line Coverage",
+    "Region Coverage",
+    "Branch Coverage",
+];
+
+function extractCoverageTotals(html) {
+    const totalsRowMatch = html.match(
+        /<tr class='light-row-bold'><td><pre>Totals<\/pre><\/td>(.*?)<\/tr>/s
+    );
+    if (!totalsRowMatch) {
+        return [];
+    }
+
+    const totals = [...totalsRowMatch[1].matchAll(/<td class='[^']*'><pre>\s*([^<]+?)\s*<\/pre><\/td>/g)]
+        .slice(0, COVERAGE_TOTAL_LABELS.length)
+        .map((match, index) => ({
+            label: COVERAGE_TOTAL_LABELS[index],
+            value: match[1].trim(),
+        }));
+
+    if (totals.length !== COVERAGE_TOTAL_LABELS.length) {
+        return [];
+    }
+
+    return totals;
+}
+
+export async function load({ fetch }) {
+    try {
+        const response = await fetch(`${env.PUBLIC_ENDPOINT}/master-fuzz-coverage`);
+        if (!response.ok) {
+            return { report: null, coverageTotals: [] };
+        }
+
+        const report = await response.json();
+        let coverageTotals = [];
+
+        if (report?.report_url) {
+            try {
+                const reportResponse = await fetch(report.report_url);
+                if (reportResponse.ok) {
+                    coverageTotals = extractCoverageTotals(await reportResponse.text());
+                }
+            } catch (error) {
+                console.error(error);
+            }
+        }
+
+        return {
+            report,
+            coverageTotals,
+        };
+    } catch (error) {
+        console.error(error);
+        return { report: null, coverageTotals: [] };
+    }
+}

--- a/frontend/src/routes/master-fuzz-coverage/+page.svelte
+++ b/frontend/src/routes/master-fuzz-coverage/+page.svelte
@@ -1,0 +1,306 @@
+<svelte:head>
+    <title>Master Fuzz Coverage</title>
+</svelte:head>
+
+<script>
+    export let data;
+
+    $: report = data.report;
+    $: coverageTotals = data.coverageTotals || [];
+
+    function formatDate(value) {
+        if (!value) return "—";
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return value;
+        return date.toLocaleString();
+    }
+
+    function getGeneratedLabel(reportData) {
+        if (!reportData) return "—";
+        return formatDate(reportData.generated_at || reportData.created_at);
+    }
+</script>
+
+<div class="master-coverage-page">
+    <div class="page-shell">
+        <div class="page-header card">
+            <div class="title-copy">
+                <div class="eyebrow">Master fuzz coverage</div>
+                <h1>LLVM fuzzing coverage report for bitcoin/bitcoin master</h1>
+                <p class="subtitle">
+                    RAW HTML coverage report generated with `llvm-cov show --format=html`
+                    by replaying the fuzz corpora from bitcoin-core/qa-assets
+                    through the fuzz harness
+                </p>
+            </div>
+
+            {#if report}
+                <div class="meta-grid">
+                    <div class="meta-card">
+                        <span class="meta-label">Master commit</span>
+                        <a
+                            class="meta-value txt-mono"
+                            href={"https://github.com/bitcoin/bitcoin/commit/" + report.commit}
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            {report.commit.slice(0, 7)}
+                        </a>
+                    </div>
+                    <div class="meta-card">
+                        <span class="meta-label">Generated</span>
+                        <span class="meta-value">{getGeneratedLabel(report)}</span>
+                    </div>
+                </div>
+            {/if}
+        </div>
+
+        {#if coverageTotals.length}
+            <section class="coverage-totals-section" aria-labelledby="coverage-totals-heading">
+                <h2 id="coverage-totals-heading" class="section-heading">Totals</h2>
+                <div class="coverage-totals">
+                    {#each coverageTotals as total}
+                        <div class="coverage-total-card">
+                            <span class="coverage-total-label">{total.label}</span>
+                            <span class="coverage-total-value txt-mono">{total.value}</span>
+                        </div>
+                    {/each}
+                </div>
+            </section>
+        {/if}
+
+        {#if !report}
+            <div class="card alert alert-info">
+                <i class="ri-information-line" /> No master fuzz coverage report is available yet.
+            </div>
+        {:else if report.status === "pending"}
+            <div class="card alert alert-warning">
+                <i class="ri-information-line" /> The latest master fuzz coverage report is
+                being generated.
+            </div>
+        {:else if report.status === "failure"}
+            <div class="card alert alert-danger">
+                <i class="ri-information-line" /> Failed to generate the latest master
+                fuzz coverage report{report.failure_reason ? `: ${report.failure_reason}` : "."}
+            </div>
+        {:else if !report.report_url}
+            <div class="card alert alert-info">
+                <i class="ri-information-line" /> Corecheck is preparing the embeddable
+                HTML report for the latest master fuzz run.
+            </div>
+        {:else}
+            <div class="report-frame card">
+                <div class="report-actions">
+                    <a
+                        href={report.report_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        class="link-primary"
+                    >
+                        Open report in a new tab
+                    </a>
+                </div>
+                <iframe
+                    title="Master fuzz coverage report"
+                    src={report.report_url}
+                    loading="eager"
+                />
+            </div>
+        {/if}
+    </div>
+</div>
+
+<style lang="scss">
+    .master-coverage-page {
+        flex: 1 1 auto;
+        min-width: 0;
+        padding: clamp(12px, 2vw, 24px);
+        height: 100%;
+        overflow: auto;
+    }
+
+    .page-shell {
+        display: flex;
+        flex-direction: column;
+        gap: clamp(16px, 2vw, 20px);
+        min-height: 100%;
+        min-width: 0;
+    }
+
+    .page-header,
+    .report-frame {
+        background: #fff;
+        border-radius: 16px;
+        padding: clamp(18px, 2vw, 24px);
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    }
+
+    .page-header {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: start;
+        gap: 16px 24px;
+        padding: clamp(16px, 1.75vw, 20px);
+    }
+
+    .title-copy {
+        min-width: 0;
+    }
+
+    .eyebrow {
+        font-size: 0.8rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #2f6fec;
+        margin-bottom: 8px;
+    }
+
+    h1 {
+        margin: 0;
+        font-size: clamp(1.65rem, 2.2vw, 1.9rem);
+        line-height: 1.2;
+    }
+
+    .subtitle {
+        margin: 8px 0 0;
+        color: #5f6b7a;
+        max-width: 60rem;
+    }
+
+    .meta-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        justify-content: flex-end;
+        align-self: start;
+    }
+
+    .meta-card {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        min-width: min(220px, 100%);
+    }
+
+    .coverage-totals {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
+        gap: 12px;
+    }
+
+    .coverage-totals-section {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        margin-top: -4px;
+    }
+
+    .section-heading {
+        margin: 0;
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #64748b;
+    }
+
+    .coverage-total-card {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 16px;
+        padding: 16px 18px;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .coverage-total-label {
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #64748b;
+    }
+
+    .coverage-total-value {
+        color: #0f172a;
+        font-size: 1.05rem;
+        font-weight: 600;
+        word-break: break-word;
+    }
+
+    .meta-label {
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #64748b;
+    }
+
+    .meta-value {
+        color: #0f172a;
+        font-weight: 600;
+        word-break: break-word;
+    }
+
+    .report-frame {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        min-height: 70vh;
+        min-width: 0;
+    }
+
+    .report-actions {
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    iframe {
+        display: block;
+        flex: 1;
+        width: 100%;
+        min-height: clamp(28rem, 70vh, 64rem);
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        background: #fff;
+    }
+
+    @media (max-width: 768px) {
+        .page-header {
+            grid-template-columns: 1fr;
+            gap: 14px;
+        }
+
+        h1 {
+            font-size: clamp(1.35rem, 4vw, 1.55rem);
+        }
+
+        .meta-grid {
+            justify-content: flex-start;
+        }
+
+        .meta-card {
+            min-width: 100%;
+        }
+
+        .coverage-total-card {
+            padding: 14px 16px;
+        }
+
+        .report-actions {
+            justify-content: flex-start;
+        }
+
+        iframe {
+            min-height: 60vh;
+        }
+    }
+</style>

--- a/functions/api/get-master-fuzz-coverage/config.go
+++ b/functions/api/get-master-fuzz-coverage/config.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/corecheck/corecheck/internal/config"
+
+type Config struct {
+	config.DatabaseConfig
+
+	BucketDataURL string `env:"BUCKET_DATA_URL" env-required:"true"`
+}

--- a/functions/api/get-master-fuzz-coverage/main.go
+++ b/functions/api/get-master-fuzz-coverage/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/corecheck/corecheck/internal/api"
+	"github.com/corecheck/corecheck/internal/config"
+	"github.com/corecheck/corecheck/internal/db"
+	"github.com/corecheck/corecheck/internal/logger"
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+type MasterFuzzCoverageResponse struct {
+	*db.CoverageReport
+	ReportURL string `json:"report_url,omitempty"`
+}
+
+var (
+	cfg = Config{}
+	log = logger.New()
+)
+
+func getLatestMasterFuzzCoverage(c echo.Context) error {
+	report, err := db.GetLatestMasterFuzzCoverageReport()
+	if err != nil {
+		log.Error(err)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return c.JSON(404, "report not found")
+		}
+		return err
+	}
+
+	response := MasterFuzzCoverageResponse{
+		CoverageReport: report,
+	}
+	if report.Status == db.COVERAGE_REPORT_STATUS_SUCCESS && report.GeneratedAt != nil {
+		response.ReportURL = fmt.Sprintf("%s/master-fuzz/%s/coverage-report/index.html", strings.TrimRight(cfg.BucketDataURL, "/"), report.Commit)
+	}
+
+	return c.JSON(200, response)
+}
+
+func main() {
+	log.Debug("Loading config...")
+	if err := config.Load(&cfg); err != nil {
+		log.Fatalf("Error loading config: %s", err)
+	}
+
+	log.Debug("Connecting to database...")
+	if err := db.Connect(cfg.DatabaseConfig); err != nil {
+		log.Fatalf("Error connecting to database: %s", err)
+	}
+
+	e := api.New()
+	e.GET("/master-fuzz-coverage", getLatestMasterFuzzCoverage)
+	api.Start(e)
+}

--- a/functions/compute/github-sync/config.go
+++ b/functions/compute/github-sync/config.go
@@ -12,4 +12,5 @@ type Config struct {
 
 	StateMachineARN    string `env:"STATE_MACHINE_ARN" env-required:"true"`
 	MutationMachineARN string `env:"MUTATION_STATE_MACHINE_ARN" env-required:"true"`
+	FuzzMachineARN     string `env:"FUZZ_STATE_MACHINE_ARN" env-required:"true"`
 }

--- a/functions/compute/github-sync/main.go
+++ b/functions/compute/github-sync/main.go
@@ -64,6 +64,88 @@ func startMasterCoverageExecution(report *db.CoverageReport, commit string) erro
 	return nil
 }
 
+func startMasterFuzzCoverageExecution(report *db.CoverageReport, commit string) error {
+	params := StateMachineInput{
+		Params: types.JobParams{
+			Commit:     commit,
+			IsMaster:   "true",
+			IsFuzz:     "true",
+			PRNumber:   "0",
+			BaseCommit: commit,
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	execution, err := stateMachine.StartExecution(&sfn.StartExecutionInput{
+		StateMachineArn: aws.String(cfg.FuzzMachineARN),
+		Input:           aws.String(string(paramsJSON)),
+	})
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	err = db.UpdateCoverageReportTrace(report.ID, aws.StringValue(execution.ExecutionArn), "")
+	if err != nil {
+		log.Errorf("Error updating fuzz coverage report trace: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func checkMasterFuzzCoverage(c *github.Client) error {
+	log.Info("Checking master fuzz coverage...")
+	master, _, err := c.Repositories.GetBranch(context.Background(), "bitcoin", "bitcoin", "master", 0)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	commit := master.GetCommit().GetSHA()
+	log.Debug("Latest commit: %s", commit)
+
+	report, err := db.GetCoverageReportByCommitMasterFuzz(commit)
+	if err == nil {
+		if report.Status == db.COVERAGE_REPORT_STATUS_PENDING {
+			log.Info("Master fuzz coverage is already pending for latest commit")
+			return nil
+		}
+		if report.GeneratedAt != nil {
+			log.Info("Master has fuzz coverage for latest commit")
+			return nil
+		}
+
+		log.Info("Master fuzz coverage exists but the HTML report is missing, re-running coverage")
+		return startMasterFuzzCoverageExecution(report, commit)
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		log.Error(err)
+		return err
+	}
+
+	log.Info("Master does not have fuzz coverage for latest commit, adding to queue")
+
+	report = &db.CoverageReport{
+		Commit:     commit,
+		IsMaster:   true,
+		IsFuzz:     true,
+		BaseCommit: commit,
+	}
+
+	err = db.CreateCoverageReport(report)
+	if err != nil {
+		log.Errorf("Error creating fuzz coverage report: %s", err)
+		return err
+	}
+
+	return startMasterFuzzCoverageExecution(report, commit)
+}
+
 func checkMasterCoverage(c *github.Client) error {
 	log.Info("Checking master coverage...")
 	master, _, err := c.Repositories.GetBranch(context.Background(), "bitcoin", "bitcoin", "master", 0)
@@ -334,6 +416,11 @@ mainLoop:
 func syncGitHubActivity(c *github.Client) error {
 	if err := checkMasterCoverage(c); err != nil {
 		log.Errorf("Error checking master coverage: %s", err)
+		return err
+	}
+
+	if err := checkMasterFuzzCoverage(c); err != nil {
+		log.Errorf("Error checking master fuzz coverage: %s", err)
 		return err
 	}
 

--- a/functions/compute/handle-fuzz-coverage/config.go
+++ b/functions/compute/handle-fuzz-coverage/config.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/corecheck/corecheck/internal/config"
+
+type Config struct {
+	config.DatabaseConfig
+}

--- a/functions/compute/handle-fuzz-coverage/main.go
+++ b/functions/compute/handle-fuzz-coverage/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/corecheck/corecheck/internal/config"
+	"github.com/corecheck/corecheck/internal/db"
+	"github.com/corecheck/corecheck/internal/logger"
+	"github.com/corecheck/corecheck/internal/types"
+	"github.com/davecgh/go-spew/spew"
+)
+
+var (
+	cfg = Config{}
+	log = logger.New()
+)
+
+func handleFuzzCoverageSuccess(job *types.JobParams) error {
+	log.Info("Handling fuzz coverage success")
+	stepFunctionExecutionARN := job.GetStepFunctionExecutionARN()
+	coverageBatchJobID := job.GetCoverageBatchJobID()
+
+	report, err := db.GetOrCreateCoverageReportByCommitMasterFuzz(job.Commit)
+	if err != nil {
+		log.Error("Error getting fuzz coverage report", err)
+		return err
+	}
+
+	err = db.UpdateCoverageReportTrace(report.ID, stepFunctionExecutionARN, coverageBatchJobID)
+	if err != nil {
+		log.Error("Error updating fuzz coverage report trace", err)
+		return err
+	}
+
+	err = db.UpdateCoverageReport(report.ID, db.COVERAGE_REPORT_STATUS_SUCCESS, report.BenchmarkStatus, report.BaseCommit)
+	if err != nil {
+		log.Error("Error updating fuzz coverage report", err)
+		return err
+	}
+
+	err = db.UpdateCoverageReportGeneratedAt(report.ID, time.Now().UTC())
+	if err != nil {
+		log.Error("Error setting fuzz coverage report generation time", err)
+		return err
+	}
+
+	log.Infof("Fuzz coverage for master updated")
+	return nil
+}
+
+func HandleRequest(ctx context.Context, event map[string]interface{}) (string, error) {
+	spew.Dump(event)
+	log.Debug("Loading config...")
+	if err := config.Load(&cfg); err != nil {
+		log.Fatalf("Error loading config: %s", err)
+	}
+
+	log.Debug("Connecting to database...")
+	if err := db.Connect(cfg.DatabaseConfig); err != nil {
+		log.Fatalf("Error connecting to database: %s", err)
+	}
+
+	params, err := types.GetJobParams(event)
+	if err != nil {
+		log.Error("Error getting job params", err)
+		return "", err
+	}
+
+	err = handleFuzzCoverageSuccess(params)
+	if err != nil {
+		log.Error("Error handling fuzz coverage success", err)
+		return "", err
+	}
+
+	return "OK", nil
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}

--- a/internal/db/coverage.go
+++ b/internal/db/coverage.go
@@ -19,6 +19,7 @@ type CoverageReport struct {
 	FailureReason            string                                   `json:"failure_reason"`
 	BenchmarkStatus          string                                   `json:"benchmark_status" gorm:"default:pending"`
 	IsMaster                 bool                                     `json:"is_master" gorm:"index:idx_coverage_reports_commit_is_master,priority:2"`
+	IsFuzz                   bool                                     `json:"is_fuzz" gorm:"index:idx_coverage_reports_commit_is_fuzz"`
 	PRNumber                 int                                      `json:"pr_number" gorm:"index:idx_coverage_reports_pr_number_created_at,priority:1"`
 	Commit                   string                                   `json:"commit" gorm:"index:idx_coverage_reports_commit_is_master,priority:1"`
 	BaseCommit               string                                   `json:"base_commit"`
@@ -98,7 +99,7 @@ func GetOrCreateCoverageReportByCommitPr(commit string, prNum int, baseCommit st
 
 func GetCoverageReportByCommitMaster(commit string) (*CoverageReport, error) {
 	var report CoverageReport
-	err := DB.Preload("Hunks").Preload("Benchmarks").Where("commit = ? AND is_master = ?", commit, true).First(&report).Error
+	err := DB.Preload("Hunks").Preload("Benchmarks").Where("commit = ? AND is_master = ? AND is_fuzz = ?", commit, true, false).First(&report).Error
 	return &report, err
 }
 
@@ -110,6 +111,35 @@ func GetOrCreateCoverageReportByCommitMaster(commit string) (*CoverageReport, er
 				Commit:     commit,
 				BaseCommit: commit,
 				IsMaster:   true,
+			}
+
+			err = CreateCoverageReport(report)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	return report, nil
+}
+
+func GetCoverageReportByCommitMasterFuzz(commit string) (*CoverageReport, error) {
+	var report CoverageReport
+	err := DB.Preload("Hunks").Preload("Benchmarks").Where("commit = ? AND is_master = ? AND is_fuzz = ?", commit, true, true).First(&report).Error
+	return &report, err
+}
+
+func GetOrCreateCoverageReportByCommitMasterFuzz(commit string) (*CoverageReport, error) {
+	report, err := GetCoverageReportByCommitMasterFuzz(commit)
+	if err != nil {
+		if err.Error() == "record not found" {
+			report = &CoverageReport{
+				Commit:     commit,
+				BaseCommit: commit,
+				IsMaster:   true,
+				IsFuzz:     true,
 			}
 
 			err = CreateCoverageReport(report)
@@ -161,7 +191,13 @@ func UpdateCoverageReportGeneratedAt(reportID int, generatedAt time.Time) error 
 
 func HasCoverageReportForCommitMaster(commit string) (bool, error) {
 	var count int64
-	err := DB.Model(&CoverageReport{}).Where("commit = ? AND is_master = ?", commit, true).Count(&count).Error
+	err := DB.Model(&CoverageReport{}).Where("commit = ? AND is_master = ? AND is_fuzz = ?", commit, true, false).Count(&count).Error
+	return count > 0, err
+}
+
+func HasCoverageReportForCommitMasterFuzz(commit string) (bool, error) {
+	var count int64
+	err := DB.Model(&CoverageReport{}).Where("commit = ? AND is_master = ? AND is_fuzz = ?", commit, true, true).Count(&count).Error
 	return count > 0, err
 }
 
@@ -187,10 +223,16 @@ func CreateCoverageHunks(reportID int, hunks []*CoverageFileHunk) error {
 
 func GetLatestMasterCoverageReport() (*CoverageReport, error) {
 	var report CoverageReport
-	err := DB.Preload("Benchmarks").Where("is_master = ? AND status = ? AND benchmark_status = ?", true, COVERAGE_REPORT_STATUS_SUCCESS, BENCHMARK_STATUS_SUCCESS).Order("created_at desc").First(&report).Error
+	err := DB.Preload("Benchmarks").Where("is_master = ? AND is_fuzz = ? AND status = ? AND benchmark_status = ?", true, false, COVERAGE_REPORT_STATUS_SUCCESS, BENCHMARK_STATUS_SUCCESS).Order("created_at desc").First(&report).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		err = DB.Preload("Benchmarks").Where("is_master = ? AND status = ?", true, COVERAGE_REPORT_STATUS_SUCCESS).Order("created_at desc").First(&report).Error
+		err = DB.Preload("Benchmarks").Where("is_master = ? AND is_fuzz = ? AND status = ?", true, false, COVERAGE_REPORT_STATUS_SUCCESS).Order("created_at desc").First(&report).Error
 	}
+	return &report, err
+}
+
+func GetLatestMasterFuzzCoverageReport() (*CoverageReport, error) {
+	var report CoverageReport
+	err := DB.Where("is_master = ? AND is_fuzz = ? AND status = ?", true, true, COVERAGE_REPORT_STATUS_SUCCESS).Order("created_at desc").First(&report).Error
 	return &report, err
 }
 
@@ -206,7 +248,7 @@ func GetLatestPullCoverageReport(prNum int) (*CoverageReport, error) {
 
 func GetMasterCoverageReport(commit string) (*CoverageReport, error) {
 	var report CoverageReport
-	err := DB.Preload("Benchmarks").Where("commit = ? AND is_master = ?", commit, true).First(&report).Error
+	err := DB.Preload("Benchmarks").Where("commit = ? AND is_master = ? AND is_fuzz = ?", commit, true, false).First(&report).Error
 	return &report, err
 }
 

--- a/internal/types/job.go
+++ b/internal/types/job.go
@@ -7,6 +7,7 @@ type JobParams struct {
 	Commit                   string `json:"commit"`
 	BaseCommit               string `json:"base_commit"`
 	IsMaster                 string `json:"is_master"`
+	IsFuzz                   string `json:"is_fuzz,omitempty"`
 	StepFunctionExecutionARN string `json:"step_function_execution_arn,omitempty"`
 	CoverageBatchJobID       string `json:"coverage_batch_job_id,omitempty"`
 }
@@ -19,6 +20,11 @@ func (j *JobParams) GetPRNumber() int {
 func (j *JobParams) GetIsMaster() bool {
 	isMaster, _ := strconv.ParseBool(j.IsMaster)
 	return isMaster
+}
+
+func (j *JobParams) GetIsFuzz() bool {
+	isFuzz, _ := strconv.ParseBool(j.IsFuzz)
+	return isFuzz
 }
 
 func (j *JobParams) GetCommit() string {
@@ -43,11 +49,13 @@ func getJobParams(event map[string]interface{}) (*JobParams, error) {
 	prNumber := params["pr_number"].(string)
 	isMaster := params["is_master"].(string)
 	baseCommit := params["base_commit"].(string)
+	isFuzz, _ := params["is_fuzz"].(string)
 
 	return &JobParams{
 		PRNumber:                 prNumber,
 		Commit:                   commit,
 		IsMaster:                 isMaster,
+		IsFuzz:                   isFuzz,
 		BaseCommit:               baseCommit,
 		StepFunctionExecutionARN: getStepFunctionExecutionARN(event),
 		CoverageBatchJobID:       getCoverageBatchJobID(event),

--- a/workers/fuzz-coverage-worker/Dockerfile
+++ b/workers/fuzz-coverage-worker/Dockerfile
@@ -1,0 +1,63 @@
+FROM ubuntu:26.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y git \
+    python3-zmq \
+    libevent-dev \
+    libboost-dev \
+    libsqlite3-dev \
+    libzmq3-dev \
+    libcapnp-dev \
+    capnproto \
+    clang \
+    llvm \
+    libclang-rt-dev \
+    build-essential \
+    libtool \
+    cmake \
+    pkg-config \
+    bsdmainutils \
+    bsdextrautils \
+    curl \
+    wget \
+    python3-pip \
+    lsb-release \
+    software-properties-common \
+    gnupg \
+    unzip \
+    jq \
+    parallel
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws
+
+RUN wget https://github.com/mozilla/sccache/releases/download/v0.7.3/sccache-v0.7.3-aarch64-unknown-linux-musl.tar.gz && \
+    tar -xvf sccache-v0.7.3-aarch64-unknown-linux-musl.tar.gz && \
+    mv sccache-v0.7.3-aarch64-unknown-linux-musl/sccache /usr/bin/sccache && \
+    chmod +x /usr/bin/sccache && \
+    rm -rf sccache-v0.7.3-aarch64-unknown-linux-musl.tar.gz sccache-v0.7.3-aarch64-unknown-linux-musl
+RUN ln -s /usr/bin/sccache /usr/bin/ccache
+
+RUN sh -c "echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list" && \
+    touch /usr/share/keyrings/datadog-archive-keyring.gpg && \
+    chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg && \
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch && \
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_C0962C7D.public | gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch && \
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch && \
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+
+RUN apt update && apt install -y datadog-agent datadog-signing-keys
+
+RUN git clone https://github.com/bitcoin/bitcoin.git /tmp/bitcoin
+WORKDIR /tmp/bitcoin
+
+RUN git config --global user.email "ci@corecheck.dev"
+RUN git config --global user.name "corecheck"
+
+COPY convert_lcov_to_gcovr.py /convert_lcov_to_gcovr.py
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh

--- a/workers/fuzz-coverage-worker/convert_lcov_to_gcovr.py
+++ b/workers/fuzz-coverage-worker/convert_lcov_to_gcovr.py
@@ -1,0 +1,140 @@
+import json
+import hashlib
+from collections import defaultdict
+
+MAX_SIGNED_32 = 2**31 - 1
+WRAPAROUND_FALLBACK = 1337
+WORKSPACE_PREFIX = "/tmp/bitcoin/"
+BUILD_WORKSPACE_PREFIX = "/tmp/bitcoin/build/"
+ALLOWED_EXTENSIONS = (".cpp", ".h", ".c")
+EXCLUDED_PREFIXES = (
+    "src/test",
+    "src/qt/test",
+    "src/wallet/test",
+    "test",
+    "src/bench",
+)
+
+def normalize_count(count):
+    # LLVM coverage bug can wrap around and yield huge unsigned values; clamp to a stable fallback.
+    if count > MAX_SIGNED_32:
+        return WRAPAROUND_FALLBACK
+    return count
+
+def md5_stub(filename, line):
+    # gcovr hashes source context; we can't reproduce it
+    # so we make a stable placeholder
+    return hashlib.md5(f"{filename}:{line}".encode()).hexdigest()
+
+def normalize_filename(filename):
+    if filename.startswith(BUILD_WORKSPACE_PREFIX):
+        return filename[len(BUILD_WORKSPACE_PREFIX):]
+    if filename.startswith(WORKSPACE_PREFIX):
+        return filename[len(WORKSPACE_PREFIX):]
+    if filename.startswith("build/src/"):
+        return filename[len("build/"):]
+    return filename
+
+
+def should_include_filename(filename):
+    if not filename.startswith("src/"):
+        return False
+
+    if filename.startswith(EXCLUDED_PREFIXES):
+        return False
+
+    return filename.endswith(ALLOWED_EXTENSIONS)
+
+def lcov_to_gcovr_json(lcov_path):
+    files = {}
+
+    current_file = None
+
+    with open(lcov_path, "r", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+
+            if line.startswith("SF:"):
+                current_file = normalize_filename(line[3:])
+                if not should_include_filename(current_file):
+                    current_file = None
+                    continue
+
+                files.setdefault(current_file, {
+                    "file": current_file,
+                    "lines": defaultdict(lambda: {
+                        "branches": []
+                    }),
+                    "functions": {}
+                })
+
+            elif line.startswith("DA:") and current_file:
+                lineno, count = line[3:].split(",")
+                lineno = int(lineno)
+                count = normalize_count(int(count))
+
+                files[current_file]["lines"][lineno].update({
+                    "line_number": lineno,
+                    "function_name": None,
+                    "count": count,
+                    "gcovr/md5": md5_stub(current_file, lineno),
+                })
+
+            elif line.startswith("BRDA:") and current_file:
+                parts = line[5:].split(",")
+                lineno = int(parts[0])
+                count = parts[3]
+
+                if count == "-":
+                    count = 0
+                else:
+                    count = normalize_count(int(count))
+
+                branchno = len(files[current_file]["lines"][lineno]["branches"])
+
+                files[current_file]["lines"][lineno]["branches"].append({
+                    "branchno": branchno,
+                    "count": count,
+                    "fallthrough": False,
+                    "throw": False,
+                    "source_block_id": 0
+                })
+
+            elif line == "end_of_record":
+                current_file = None
+
+    # Final assembly
+    out = {
+        "gcovr/format_version": "0.14",
+        "files": []
+    }
+
+    for f in files.values():
+        out["files"].append({
+            "file": f["file"],
+            "lines": [
+                {
+                    **line,
+                    "branches": line["branches"]
+                }
+                for _, line in sorted(f["lines"].items())
+            ],
+            "functions": []  # cannot be reconstructed from LCOV
+        })
+
+    return out
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 3:
+        print("usage: lcov_to_gcovr.py coverage.info output.json")
+        sys.exit(1)
+
+    data = lcov_to_gcovr_json(sys.argv[1])
+
+    with open(sys.argv[2], "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+    print("Wrote gcovr-style JSON")

--- a/workers/fuzz-coverage-worker/entrypoint.sh
+++ b/workers/fuzz-coverage-worker/entrypoint.sh
@@ -1,0 +1,81 @@
+#!/bin/bash -x
+
+COMMIT=$1
+
+set -e
+
+sh -c "sed \"s/api_key:.*/api_key: $DD_API_KEY/\" /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+sh -c "sed -i 's/# site:.*/site: datadoghq.eu/' /etc/datadog-agent/datadog.yaml"
+sh -c "sed -i 's/# hostname:.*/hostname: $HOSTNAME/' /etc/datadog-agent/datadog.yaml"
+
+/etc/init.d/datadog-agent start
+ccache --show-stats
+
+cd /tmp/bitcoin && git fetch origin master && git checkout "$COMMIT"
+
+S3_COVERAGE_FILE=s3://$S3_BUCKET_DATA/master-fuzz/$COMMIT/coverage.json
+S3_SRC_PATH=s3://$S3_BUCKET_DATA/master-fuzz/$COMMIT/src
+S3_COVERAGE_HTML_REPORT_PREFIX=s3://$S3_BUCKET_DATA/master-fuzz/$COMMIT/coverage-report
+S3_COVERAGE_HTML_REPORT_INDEX=$S3_COVERAGE_HTML_REPORT_PREFIX/index.html
+
+set +e
+coverage_exists=$(aws s3 ls $S3_COVERAGE_FILE)
+html_exists=$(aws s3 ls $S3_COVERAGE_HTML_REPORT_INDEX)
+set -e
+
+if [ "$coverage_exists" != "" ] && [ "$html_exists" != "" ]; then
+    echo "Fuzz coverage data already exists for this commit"
+else
+    # Build the fuzz binary with source-based coverage instrumentation.
+    # BUILD_FOR_FUZZING=ON produces build/bin/fuzz (libFuzzer when compiling with clang).
+    time cmake -B build -DCMAKE_C_COMPILER="clang" \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_CXX_COMPILER="clang++" \
+        -DBUILD_FOR_FUZZING=ON \
+        -DAPPEND_CFLAGS="-fprofile-instr-generate -fcoverage-mapping" \
+        -DAPPEND_CXXFLAGS="-fprofile-instr-generate -fcoverage-mapping" \
+        -DAPPEND_LDFLAGS="-fprofile-instr-generate -fcoverage-mapping"
+    time cmake --build build -j$(nproc)
+
+    # Fetch the fuzz corpora (inputs) maintained by bitcoin-core/qa-assets.
+    rm -rf /tmp/qa-assets
+    git clone --depth 1 https://github.com/bitcoin-core/qa-assets.git /tmp/qa-assets
+
+    # Create directory for raw profile data. %m_%p keeps one profraw per
+    # fuzz target binary image and process so parallel replays don't clobber.
+    mkdir -p build/raw_profile_data
+    export LLVM_PROFILE_FILE="$(pwd)/build/raw_profile_data/%m_%p.profraw"
+
+    # Replay every corpus input through its fuzz target (libFuzzer -runs=1).
+    # The build-dir runner reads build/test/config.ini and defaults the binary
+    # to build/bin/fuzz.
+    time python3 ./build/test/fuzz/test_runner.py -j$(nproc) /tmp/qa-assets/fuzz_corpora 2>&1 | tee fuzz-tests.log
+
+    # Merge all the raw profile data into a single file
+    find build/raw_profile_data -name "*.profraw" > build/profraw_files.txt
+    llvm-profdata merge -f build/profraw_files.txt -o build/coverage.profdata
+
+    # Export to lcov then convert to the gcovr json format the rest of the app consumes.
+    time llvm-cov export --format=lcov --object=build/bin/fuzz --instr-profile=build/coverage.profdata --ignore-filename-regex="src/crc32c/|src/leveldb/|src/minisketch/|src/secp256k1/|src/test/" -Xdemangler=llvm-cxxfilt > build/coverage.info
+
+    python3 /convert_lcov_to_gcovr.py build/coverage.info coverage.json
+
+    aws s3 cp coverage.json $S3_COVERAGE_FILE
+
+    rm -rf build/coverage-html
+    time llvm-cov show build/bin/fuzz --instr-profile=build/coverage.profdata --ignore-filename-regex="src/crc32c/|src/leveldb/|src/minisketch/|src/secp256k1/|src/test/" -Xdemangler=llvm-cxxfilt --format=html --output-dir=build/coverage-html
+    aws s3 sync --delete build/coverage-html $S3_COVERAGE_HTML_REPORT_PREFIX
+fi
+
+# store src folder if it doesn't exist
+set +e
+src_exists=$(aws s3 ls $S3_SRC_PATH)
+set -e
+
+if [ "$src_exists" == "" ]; then
+    make clean || true
+    rm -rf src/qt src/leveldb src/test src/wallet/test src/test src/univalue src/minisketch/ src/secp256k1 src/crc32c
+    find . -name .deps -type d -exec rm -rf {} +
+    aws s3 rm --recursive $S3_SRC_PATH
+    aws s3 sync src $S3_SRC_PATH
+fi


### PR DESCRIPTION
Duplicate the master-coverage flow to produce an LLVM coverage report for bitcoin/bitcoin master generated by replaying the fuzz corpora from bitcoin-core/qa-assets through the fuzz harness.

- workers/fuzz-coverage-worker: builds the fuzz binary with coverage instrumentation, replays qa-assets/fuzz_corpora, and uploads the coverage.json + HTML report to the master-fuzz/<commit>/ S3 prefix
- db: add IsFuzz discriminator to CoverageReport (+ index) and fuzz query helpers; existing master queries now exclude fuzz reports
- functions: get-master-fuzz-coverage API + handle-fuzz-coverage lambda; github-sync enqueues a fuzz run on each new master HEAD
- terraform: ECR repo, batch job def, start-fuzz-jobs state machine, API gateway route, env wiring
- frontend: /master-fuzz-coverage route + nav link